### PR TITLE
Adding a function to create RichText with line breaks

### DIFF
--- a/src/main/java/org/vaadin/maddon/label/RichText.java
+++ b/src/main/java/org/vaadin/maddon/label/RichText.java
@@ -70,6 +70,14 @@ public class RichText extends Label {
         }
     }
 
+    /**
+     * Only replaces all new line characters with &ltbr /&gt, but no Markdown
+     * processing.
+     */
+    public RichText withNewLines(String text) {
+        return setRichText(text.replaceAll("(\\r|\\n|\\r\\n)+", "<br />"));
+    }
+
     public Whitelist getWhitelist() {
         return whitelist;
     }


### PR DESCRIPTION
I often use Label with no html tags but I'd like to keep the line breaks. So I added this function. Maybe you like to integrate it in the add-on too.
