### PR TITLE
ListContainer and empty backing list

### DIFF
--- a/src/main/java/org/vaadin/maddon/ListContainer.java
+++ b/src/main/java/org/vaadin/maddon/ListContainer.java
@@ -51,8 +51,13 @@ public class ListContainer<T> extends AbstractContainer implements
         setCollection(backingList);
     }
 
+    public ListContainer(Class<T> type, Collection<T> backingList) {
+        dynaClass = WrapDynaClass.createDynaClass(type);
+        setCollection(backingList);
+    }
+    
     public final void setCollection(Collection<T> backingList1) {
-        if (backingList1.getClass().isAssignableFrom(List.class)) {
+        if (backingList1.getClass().isAssignableFrom(List.class) || backingList1.isEmpty()) {
             this.backingList = (List<T>) backingList1;
         } else {
             this.backingList = new ArrayList<T>(backingList1);

--- a/src/test/java/org/vaadin/maddon/DynaBeanBasedContainer.java
+++ b/src/test/java/org/vaadin/maddon/DynaBeanBasedContainer.java
@@ -18,13 +18,19 @@ package org.vaadin.maddon;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.BeanItemContainer;
+import com.vaadin.ui.Table;
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.logging.Logger;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  *
@@ -49,6 +55,67 @@ public class DynaBeanBasedContainer {
 
     private List<Person> persons = getListOfPersons(amount);
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    
+    @Test
+    public void testEmptyList() {
+    	List<Person> l = new ArrayList<Person>();
+    	// Test with BeanItemContainer
+    	System.out.println("BeanItemContainer with empty list");
+    	BeanItemContainer<Person> bc = new BeanItemContainer<Person>(Person.class, l);
+    	System.out.println("   container size=" + bc.size());
+    	System.out.print("Properties: ");
+    	for (String p : bc.getContainerPropertyIds()) {
+    		System.out.print(p + " ");
+    	}
+
+    	// Test ListContainer with setCollection call
+    	System.out.println("\n\nListContainer with empty list via setCollection");
+    	ListContainer<Person> lc = new ListContainer<Person>(Person.class);
+    	lc.setCollection(l);
+    	System.out.println("   container size=" + lc.size());
+    	System.out.print("Properties: ");
+    	for (String p : lc.getContainerPropertyIds()) {
+    		System.out.print(p + " ");
+    	}
+
+    	// Test ListContainer with setCollection call
+    	System.out.println("\n\nListContainer with Class<T>, Collection<T> constructor");
+    	lc = new ListContainer<Person>(Person.class, l);
+    	System.out.println("   container size=" + lc.size());
+    	System.out.print("Properties: ");
+    	for (String p : lc.getContainerPropertyIds()) {
+    		System.out.print(p + " ");
+    	}
+        Person per = new Person();
+        per.setFirstName("First") ;
+        per.setLastName("Lastname");
+        per.setAge(r.nextInt(100));
+    	lc.addItem(per);
+    	System.out.println("\n   container size after addItem = " + lc.size());
+
+        Person per2 = new Person();
+        per2.setFirstName("Firs") ;
+        per2.setLastName("Lastnam");
+        per2.setAge(r.nextInt(100));
+    	l.add(per2);
+    	System.out.println("   container size after add = " + lc.size());
+
+    	
+    	// Test ListContainer with constructor that takes the List -- empty List 
+    	// will cause exception in getDynaClass method when properties are accessed
+    	System.out.println("\n\nListContainer with empty list via Collection<T> constructor");
+    	l = new ArrayList<Person>();
+    	lc = new ListContainer<Person>(l);
+    	System.out.println("   container size=" + lc.size());
+    	System.out.println("Properties: none should print due to exception");
+    	thrown.expect(IndexOutOfBoundsException.class);
+    	for (String p : lc.getContainerPropertyIds()) {
+    		System.out.print(p + " ");
+    	}
+    }
+    
     @Test
     public void testMemoryUsage() {
         System.out.println("\n Testing List container from Maddon");


### PR DESCRIPTION
The ListContainer(Collection<T>) constructor is dangerous and perhaps should be deprecated.  If the backing list is empty, an IndexOutOfBoundsException will be thrown in the getDynaClass method when properties are accessed.  See the testEmptyList method I added to the DynaBeanBasedContainer test.

I added a (Class<T>, Collection<T>) constructor (ala BeanItemContainer) and made a slight mod to setCollection that allows the empty list to be the backing list rather than creating a new empty list (it surprised me, but isAssignableFrom appears to return false for empty lists).
