### PR TITLE
Should not NPE when backingList.isEmpty()

### DIFF
--- a/src/main/java/org/vaadin/maddon/ListContainer.java
+++ b/src/main/java/org/vaadin/maddon/ListContainer.java
@@ -271,6 +271,7 @@ public class ListContainer<T> extends AbstractContainer implements
 
     @Override
     public Collection<?> getSortableContainerPropertyIds() {
+        if (backingList.isEmpty()) return Collections.emptyList();
         ArrayList<String> properties = new ArrayList<String>();
         for (DynaProperty db : getDynaClass().getDynaProperties()) {
             if (db.getType().isPrimitive() || Comparable.class.isAssignableFrom(


### PR DESCRIPTION
- getSortableContainerPropertyIds() now returns an empty collection
  instead of throwing NPE when backingList is empty
