### PR TITLE
sort() should not throw ArrayIndexOutOfBounds on empty array

### DIFF
--- a/src/main/java/org/vaadin/maddon/ListContainer.java
+++ b/src/main/java/org/vaadin/maddon/ListContainer.java
@@ -259,6 +259,9 @@ public class ListContainer<T> extends AbstractContainer implements
 
     @Override
     public void sort(Object[] propertyId, boolean[] ascending) {
+        if (propertyId.length == 0) {
+            return;
+        }
         Comparator c = new NullComparator();
         if (!ascending[0]) {
             c = new ReverseComparator(c);


### PR DESCRIPTION
this is allowed by the API... just `return` if the first arg is zero. 
Apparently, this is _required_ for `ListContainer` to work with the new `Grid`! Otherwise it will crash on startup.
