### PR TITLE
DeleteButton for AbstractForm

### DIFF
--- a/src/main/java/org/vaadin/viritin/button/DeleteButton.java
+++ b/src/main/java/org/vaadin/viritin/button/DeleteButton.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vaadin.viritin.button;
+
+/**
+ * A delete button, commonly used for deleting an entity. Automatically sets
+ * "danger" class name and open a confirmation dialog.
+ */
+public class DeleteButton extends ConfirmButton {
+
+    public DeleteButton() {
+        setupDeleteButton();
+    }
+
+    public DeleteButton(String caption) {
+        setCaption(caption);
+        setupDeleteButton();
+    }
+
+    public DeleteButton(String caption, String confirmationText, ClickListener listener) {
+        super(caption, confirmationText, listener);
+        setupDeleteButton();
+    }
+
+    private void setupDeleteButton() {
+        setStyleName("danger default");
+    }
+
+}

--- a/src/main/java/org/vaadin/viritin/button/MButton.java
+++ b/src/main/java/org/vaadin/viritin/button/MButton.java
@@ -69,4 +69,9 @@ public class MButton extends Button {
         return this;
     }
 
+    public MButton withVisible(boolean visible) {
+        setVisible(visible);
+        return this;
+    }
+
 }

--- a/src/main/java/org/vaadin/viritin/form/AbstractForm.java
+++ b/src/main/java/org/vaadin/viritin/form/AbstractForm.java
@@ -129,14 +129,17 @@ public abstract class AbstractForm<T> extends CustomComponent implements
 
     public void setSavedHandler(SavedHandler<T> savedHandler) {
         this.savedHandler = savedHandler;
+        getSaveButton().setVisible(this.savedHandler != null);
     }
 
     public void setResetHandler(ResetHandler<T> resetHandler) {
         this.resetHandler = resetHandler;
+        getResetButton().setVisible(this.resetHandler != null);
     }
 
     public void setDeleteHandler(DeleteHandler<T> deleteHandler) {
         this.deleteHandler = deleteHandler;
+        getDeleteButton().setVisible(this.deleteHandler != null);
     }
 
     public ResetHandler<T> getResetHandler() {
@@ -171,7 +174,8 @@ public abstract class AbstractForm<T> extends CustomComponent implements
     }
 
     protected Button createCancelButton() {
-        return new MButton("Cancel");
+        return new MButton("Cancel")
+                .withVisible(false);
     }
     private Button resetButton;
 
@@ -194,7 +198,8 @@ public abstract class AbstractForm<T> extends CustomComponent implements
     }
 
     protected Button createSaveButton() {
-        return new PrimaryButton("Save");
+        return new PrimaryButton("Save")
+                .withVisible(false);
     }
 
     private Button saveButton;
@@ -218,7 +223,8 @@ public abstract class AbstractForm<T> extends CustomComponent implements
     }
 
     protected Button createDeleteButton() {
-        return new DeleteButton("Delete");
+        return new DeleteButton("Delete")
+                .withVisible(false);
     }
 
     private Button deleteButton;

--- a/src/main/java/org/vaadin/viritin/form/AbstractForm.java
+++ b/src/main/java/org/vaadin/viritin/form/AbstractForm.java
@@ -12,6 +12,7 @@ import com.vaadin.ui.Window;
 import org.vaadin.viritin.BeanBinder;
 import org.vaadin.viritin.MBeanFieldGroup;
 import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
+import org.vaadin.viritin.button.DeleteButton;
 import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.button.PrimaryButton;
 import org.vaadin.viritin.layouts.MHorizontalLayout;
@@ -78,9 +79,15 @@ public abstract class AbstractForm<T> extends CustomComponent implements
         void onReset(T entity);
     }
 
+    public interface DeleteHandler<T> {
+
+        void onDelete(T entity);
+    }
+
     private T entity;
     private SavedHandler<T> savedHandler;
     private ResetHandler<T> resetHandler;
+    private DeleteHandler<T> deleteHandler;
     private boolean eagerValidation = true;
 
     public boolean isEagerValidation() {
@@ -128,12 +135,20 @@ public abstract class AbstractForm<T> extends CustomComponent implements
         this.resetHandler = resetHandler;
     }
 
+    public void setDeleteHandler(DeleteHandler<T> deleteHandler) {
+        this.deleteHandler = deleteHandler;
+    }
+
     public ResetHandler<T> getResetHandler() {
         return resetHandler;
     }
 
     public SavedHandler<T> getSavedHandler() {
         return savedHandler;
+    }
+
+    public DeleteHandler<T> getDeleteHandler() {
+        return deleteHandler;
     }
 
     public Window openInModalPopup() {
@@ -145,12 +160,13 @@ public abstract class AbstractForm<T> extends CustomComponent implements
     }
 
     /**
-     * @return A default toolbar containing save/cancel buttons
+     * @return A default toolbar containing save/cancel/delete buttons
      */
     public HorizontalLayout getToolbar() {
         return new MHorizontalLayout(
                 getSaveButton(),
-                getResetButton()
+                getResetButton(),
+                getDeleteButton()
         );
     }
 
@@ -201,12 +217,40 @@ public abstract class AbstractForm<T> extends CustomComponent implements
         return saveButton;
     }
 
+    protected Button createDeleteButton() {
+        return new DeleteButton("Delete");
+    }
+
+    private Button deleteButton;
+
+    public void setDeleteButton(final Button deleteButton) {
+        this.deleteButton = deleteButton;
+        deleteButton.addClickListener(new Button.ClickListener() {
+
+            @Override
+            public void buttonClick(Button.ClickEvent event) {
+                delete(event);
+            }
+        });
+    }
+
+    public Button getDeleteButton() {
+        if (deleteButton == null) {
+            setDeleteButton(createDeleteButton());
+        }
+        return deleteButton;
+    }
+
     protected void save(Button.ClickEvent e) {
-        savedHandler.onSave(entity);
+        savedHandler.onSave(getEntity());
     }
 
     protected void reset(Button.ClickEvent e) {
-        resetHandler.onReset(entity);
+        resetHandler.onReset(getEntity());
+    }
+
+    protected void delete(Button.ClickEvent e) {
+        deleteHandler.onDelete(getEntity());
     }
 
     public void focusFirst() {

--- a/src/test/java/org/vaadin/viritin/it/EditPerson.java
+++ b/src/test/java/org/vaadin/viritin/it/EditPerson.java
@@ -37,7 +37,7 @@ public class EditPerson extends AbstractTest {
         }
     }
 
-    public static class PersonForm<Person> extends AbstractForm {
+    public static class PersonForm extends AbstractForm<Person> {
 
         private MTextField firstName = new MTextField("Name");
 
@@ -76,6 +76,14 @@ public class EditPerson extends AbstractTest {
             @Override
             public void onSave(Person entity) {
                 Notification.show(entity.toString());
+            }
+        });
+
+        form.setDeleteHandler(new AbstractForm.DeleteHandler<Person>() {
+
+            @Override
+            public void onDelete(Person entity) {
+                Notification.show("Delete: " + entity.toString());
             }
         });
 


### PR DESCRIPTION
I created a new class DeleteButton, which extends ConfirmButton and included the DeleteButton into AbstractForm. I think that it is not necessary to adjust the state of the DeleteButton within AbstractForm like the Reset- or SaveButton. The methods savedHandler.onSave and resetHandler.onReset now use getEntity, which is better for inheritance; e.g. for customization of AbstractForm.