### PR TITLE
Add getBean() in DynaBeanItem for symmetry with BeanItem

### DIFF
--- a/src/main/java/org/vaadin/viritin/DynaBeanItem.java
+++ b/src/main/java/org/vaadin/viritin/DynaBeanItem.java
@@ -74,6 +74,10 @@ public class DynaBeanItem<T> implements Item {
         this.bean = bean;
     }
 
+    public T getBean() {
+        return bean;
+    }
+
     private DynaBean getDynaBean() {
         if (db == null) {
             db = new WrapDynaBean(bean);

--- a/src/main/java/org/vaadin/viritin/ListContainer.java
+++ b/src/main/java/org/vaadin/viritin/ListContainer.java
@@ -391,6 +391,10 @@ public class ListContainer<T> extends AbstractContainer implements
             this.bean = bean;
         }
 
+        public T getBean() {
+            return bean;
+        }
+
         private DynaBean getDynaBean() {
             if (db == null) {
                 db = new WrapDynaBean(bean);


### PR DESCRIPTION
Most Containers implement the getBean()/getEntity() method on their Item rather than on their container. 

Apparently there is no technical reason that prevents Viritin from doing the same (beside the Container.getItem() mechanism which is already in place). Adding this method makes the API of the DynaBeanItem more symmetrical to the behavior of other container implementations, such as BeanItemContainer and JPAContainer (and MongoContainer, which uses Vaadin's BeanItem implementation)

