### PR TITLE
Expose underlying unfiltered list in FilterableListContainer

### DIFF
--- a/src/main/java/org/vaadin/viritin/FilterableListContainer.java
+++ b/src/main/java/org/vaadin/viritin/FilterableListContainer.java
@@ -115,6 +115,10 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
         return isFiltered() ? filteredItems : super.getBackingList();
     }
 
+    public List<T> getUnfilteredItemIds() {
+      return super.getBackingList();
+    }
+
     @Override
     public T getIdByIndex(int index) {
         return getBackingList().get(index);


### PR DESCRIPTION
Currently there is no way to access the underlying (unfiltered) list of data that exists within a table once it has been filtered. Exposing the underlying itemIds will allow access to that data.