### PR TITLE
Abstract Form : Cancel Button always enabled in popup

### DIFF
--- a/src/main/java/org/vaadin/viritin/form/AbstractForm.java
+++ b/src/main/java/org/vaadin/viritin/form/AbstractForm.java
@@ -156,7 +156,7 @@ public abstract class AbstractForm<T> extends CustomComponent implements
             if (isBound()) {
                 fieldGroup.unbind();
             }
-            fieldGroup = BeanBinder.bind(entity, this);
+            fieldGroup = bindEntity(entity);
             isValid = fieldGroup.isValid();
             if (isEagerValidation()) {
                 fieldGroup.withEagerValidation(this);
@@ -169,6 +169,16 @@ public abstract class AbstractForm<T> extends CustomComponent implements
             setVisible(false);
             return null;
         }
+    }
+
+    /**
+     * Creates a field group, configures the fields, binds the entity to those fields
+     *
+     * @param entity The entity to bind
+     * @return the fieldGroup created
+     */
+    protected MBeanFieldGroup<T> bindEntity(T entity) {
+        return BeanBinder.bind(entity, this);
     }
 
     /**

--- a/src/main/java/org/vaadin/viritin/form/AbstractForm.java
+++ b/src/main/java/org/vaadin/viritin/form/AbstractForm.java
@@ -47,6 +47,7 @@ public abstract class AbstractForm<T> extends CustomComponent implements
             @Override
             public void attach(AttachEvent event) {
                 lazyInit();
+                adjustResetButtonState();
             }
         });
     }


### PR DESCRIPTION
Abstract Form : Always adjust the reset/cancel button state when the form is attached, thus ensuring that the resetButton is always enabled when in displayed in a popup.

Resolves viritin/viritin#49