### PR TITLE
MSize utility

### DIFF
--- a/src/main/java/org/vaadin/viritin/MSize.java
+++ b/src/main/java/org/vaadin/viritin/MSize.java
@@ -1,0 +1,95 @@
+package org.vaadin.viritin;
+
+import com.vaadin.server.SizeWithUnit;
+import com.vaadin.server.Sizeable;
+
+import java.io.Serializable;
+
+/**
+ * Created on 23/09/2015.
+ *
+ * @author Panos Bariamis
+ */
+public class MSize implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final MSize FULL_WIDTH = MSize.width(100, Sizeable.Unit.PERCENTAGE);
+    public static final MSize FULL_HEIGHT = MSize.height(100, Sizeable.Unit.PERCENTAGE);
+    public static final MSize FULL_SIZE = MSize.size(100, Sizeable.Unit.PERCENTAGE, 100, Sizeable.Unit.PERCENTAGE);
+    public static final MSize HALF_WIDTH = MSize.width(50, Sizeable.Unit.PERCENTAGE);
+    public static final MSize HALF_HEIGHT = MSize.height(50, Sizeable.Unit.PERCENTAGE);
+    public static final MSize HALF_SIZE = MSize.size(50, Sizeable.Unit.PERCENTAGE, 50, Sizeable.Unit.PERCENTAGE);
+
+    private float width = -1;
+    private float height = -1;
+    private Sizeable.Unit widthUnit = Sizeable.Unit.PIXELS;
+    private Sizeable.Unit heightUnit = Sizeable.Unit.PIXELS;
+
+    private MSize(float width, Sizeable.Unit widthUnit, float height, Sizeable.Unit heightUnit) {
+        this.width = width;
+        this.widthUnit = widthUnit;
+        this.height = height;
+        this.heightUnit = heightUnit;
+    }
+
+    public float getWidth() {
+        return width;
+    }
+
+    public Sizeable.Unit getWidthUnit() {
+        return widthUnit;
+    }
+
+    public float getHeight() {
+        return height;
+    }
+
+    public Sizeable.Unit getHeightUnit() {
+        return heightUnit;
+    }
+
+    public static MSize width(float width, Sizeable.Unit widthUnit) {
+        return new MSize(width, widthUnit, -1, Sizeable.Unit.PIXELS);
+    }
+
+    public static MSize width(String width) {
+        SizeWithUnit size = SizeWithUnit.parseStringSize(width);
+        return size != null
+                ? new MSize(size.getSize(), size.getUnit(), -1, Sizeable.Unit.PIXELS)
+                : new MSize(-1, Sizeable.Unit.PIXELS, -1, Sizeable.Unit.PIXELS);
+    }
+
+    public static MSize height(float height, Sizeable.Unit heightUnit) {
+        return new MSize(-1, Sizeable.Unit.PIXELS, height, heightUnit);
+    }
+
+    public static MSize height(String height) {
+        SizeWithUnit size = SizeWithUnit.parseStringSize(height);
+        return size != null
+                ? new MSize(-1, Sizeable.Unit.PIXELS, size.getSize(), size.getUnit())
+                : new MSize(-1, Sizeable.Unit.PIXELS, -1, Sizeable.Unit.PIXELS);
+    }
+
+    public static MSize size(float width, Sizeable.Unit widthUnit, float height, Sizeable.Unit heightUnit) {
+        return new MSize(width, widthUnit, height, heightUnit);
+    }
+
+    public static MSize size(String width, String height) {
+        float w = -1, h = -1;
+        Sizeable.Unit wu = Sizeable.Unit.PIXELS, hu = Sizeable.Unit.PIXELS;
+
+        SizeWithUnit size = SizeWithUnit.parseStringSize(width);
+        if (size != null) {
+            w = size.getSize();
+            wu = size.getUnit();
+        }
+
+        size = SizeWithUnit.parseStringSize(height);
+        if (size != null) {
+            h = size.getSize();
+            hu = size.getUnit();
+        }
+
+        return new MSize(w, wu, h, hu);
+    }
+}

--- a/src/main/java/org/vaadin/viritin/layouts/MCssLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MCssLayout.java
@@ -3,6 +3,7 @@ package org.vaadin.viritin.layouts;
 import com.vaadin.server.Resource;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CssLayout;
+import org.vaadin.viritin.MSize;
 
 public class MCssLayout extends CssLayout {
 
@@ -30,6 +31,12 @@ public class MCssLayout extends CssLayout {
 
     public MCssLayout withFullHeight() {
         setHeight("100%");
+        return this;
+    }
+
+    public MCssLayout withSize(MSize size) {
+        setWidth(size.getWidth(), size.getWidthUnit());
+        setHeight(size.getHeight(), size.getHeightUnit());
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MFormLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MFormLayout.java
@@ -4,6 +4,7 @@ import com.vaadin.server.Resource;
 import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.FormLayout;
+import org.vaadin.viritin.MSize;
 
 public class MFormLayout extends FormLayout {
 
@@ -44,12 +45,18 @@ public class MFormLayout extends FormLayout {
         return this;
     }
 
+    public MFormLayout withSize(MSize size) {
+        setWidth(size.getWidth(), size.getWidthUnit());
+        setHeight(size.getHeight(), size.getHeightUnit());
+        return this;
+    }
+
     public MFormLayout withStyleName(String styleName) {
         setStyleName(styleName);
         return this;
     }
-    
-    
+
+
     public MFormLayout withIcon(Resource icon) {
         setIcon(icon);
         return this;

--- a/src/main/java/org/vaadin/viritin/layouts/MGridLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MGridLayout.java
@@ -5,6 +5,8 @@ import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.GridLayout;
+import org.vaadin.viritin.MSize;
+
 import java.util.Collection;
 
 public class MGridLayout extends GridLayout {
@@ -56,6 +58,12 @@ public class MGridLayout extends GridLayout {
 
     public MGridLayout withFullHeight() {
         setHeight("100%");
+        return this;
+    }
+
+    public MGridLayout withSize(MSize size) {
+        setWidth(size.getWidth(), size.getWidthUnit());
+        setHeight(size.getHeight(), size.getHeightUnit());
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
@@ -6,6 +6,8 @@ import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
+import org.vaadin.viritin.MSize;
+
 import java.util.Collection;
 
 public class MHorizontalLayout extends HorizontalLayout {
@@ -39,6 +41,11 @@ public class MHorizontalLayout extends HorizontalLayout {
         return this;
     }
 
+    public MHorizontalLayout withIcon(Resource icon) {
+        setIcon(icon);
+        return this;
+    }
+
     public MHorizontalLayout withWidth(String width) {
         setWidth(width);
         return this;
@@ -54,13 +61,14 @@ public class MHorizontalLayout extends HorizontalLayout {
         return this;
     }
 
-    public MHorizontalLayout withIcon(Resource icon) {
-        setIcon(icon);
-        return this;
-    }
-    
     public MHorizontalLayout withFullHeight() {
         setHeight("100%");
+        return this;
+    }
+
+    public MHorizontalLayout withSize(MSize size) {
+        setWidth(size.getWidth(), size.getWidthUnit());
+        setHeight(size.getHeight(), size.getHeightUnit());
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
@@ -5,6 +5,8 @@ import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.VerticalLayout;
+import org.vaadin.viritin.MSize;
+
 import java.util.Collection;
 
 public class MVerticalLayout extends VerticalLayout {
@@ -56,6 +58,12 @@ public class MVerticalLayout extends VerticalLayout {
 
     public MVerticalLayout withFullHeight() {
         setHeight("100%");
+        return this;
+    }
+
+    public MVerticalLayout withSize(MSize size) {
+        setWidth(size.getWidth(), size.getWidthUnit());
+        setHeight(size.getHeight(), size.getHeightUnit());
         return this;
     }
 
@@ -114,7 +122,7 @@ public class MVerticalLayout extends VerticalLayout {
         setStyleName(styleName);
         return this;
     }
-    
+
     public MVerticalLayout withIcon(Resource icon) {
         setIcon(icon);
         return this;

--- a/src/main/java/org/vaadin/viritin/layouts/MWindow.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MWindow.java
@@ -2,6 +2,7 @@ package org.vaadin.viritin.layouts;
 
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Window;
+import org.vaadin.viritin.MSize;
 
 public class MWindow extends Window {
 
@@ -62,4 +63,9 @@ public class MWindow extends Window {
         return this;
     }
 
+    public MWindow withSize(MSize size) {
+        setWidth(size.getWidth(), size.getWidthUnit());
+        setHeight(size.getHeight(), size.getHeightUnit());
+        return this;
+    }
 }


### PR DESCRIPTION
Add MSize utility in layouts. A way to specify width and height.
I used it in my custom components and i thought it would be helpful if viritin layouts had this utility.
It could also be added in fields.

e.g.

setContent(new MVerticalLayout().withSize(MSize.FULL_WIDTH));
setContent(new MVerticalLayout().withSize(MSize.FULL_SIZE));
setContent(new MVerticalLayout().withSize(MSize.size("50px", "100px")));
