### PR TITLE
adds removeStyleName to the TypedSelect<T> class

### DIFF
--- a/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
@@ -84,6 +84,13 @@ public class TypedSelect<T> extends CustomField {
         getSelect().addStyleName(style);
         super.addStyleName(style);
     }
+    
+    
+    @Override
+    public void removeStyleName(String style) {
+    	getSelect().removeStyleName(style);
+    	super.removeStyleName(style);
+    }
 
     @Override
     public void setStyleName(String style) {


### PR DESCRIPTION
Without the implementation of the removeStyleName method the style does not get removed from the AbstractSelect element.