### PR TITLE
fix felix osgi settings (embed markdown4j), now starts up in karaf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,10 @@
                     <instructions>
                         <Embed-Dependency>markdown4j;scope=compile|runtime</Embed-Dependency>
                         <Export-Package>org.vaadin.viritin.*</Export-Package>
+                        <Import-Package>
+                            org.markdown4j;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -210,12 +210,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <Embed-Dependency>markdown4j;scope=compile|runtime</Embed-Dependency>
                         <Export-Package>org.vaadin.viritin.*</Export-Package>
-                        <Import-Package>
-                            !org.markdown4j;resolution,
-                            *,
-                            org.markdown4j;resolution:=optional
-                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Tested with karaf 4.0.4 fresh install.

untar and execute bin/karaf.

First load all dependencys (they are not in the correct order, just execute all commands, then do bundle:list and bundle:start  + the ID of the two bundles who did not start before).

install -s mvn:org.vaadin.addon/confirmdialog/2.1.3
install -s mvn:org.apache.commons/commons-lang3/3.4
install -s mvn:commons-io/commons-io/2.4
install -s mvn:commons-collections/commons-collections/3.2.2
install -s mvn:commons-beanutils/commons-beanutils/1.9.2
install -s mvn:javax.validation/validation-api/1.1.0.Final
install -s mvn:com.vaadin.external.flute/flute/1.3.0.gg2
install -s mvn:com.vaadin.external.streamhtmlparser/streamhtmlparser-jsilver/0.0.10.vaadin1
install -s mvn:com.vaadin/vaadin-shared/7.6.2
install -s mvn:com.vaadin.external.google/guava/16.0.1.vaadin1
install -s mvn:org.jsoup/jsoup/1.8.3
install -s mvn:javax.servlet/javax.servlet-api/3.1.0
install -s mvn:com.vaadin/vaadin-server/7.6.2

Then start the viritin bundle:
install -s mvn:org.vaadin/viritin/1.45-SNAPSHOT