### PR TITLE
improve withStyleName - allow variable list

### DIFF
--- a/src/main/java/org/vaadin/viritin/button/MButton.java
+++ b/src/main/java/org/vaadin/viritin/button/MButton.java
@@ -56,8 +56,10 @@ public class MButton extends Button {
         return this;
     }
 
-    public MButton withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MButton withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/MDateField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MDateField.java
@@ -100,8 +100,10 @@ public class MDateField extends DateField {
         return this;
     }
 
-    public MDateField withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MDateField withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/MTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTable.java
@@ -455,8 +455,10 @@ public class MTable<T> extends Table {
         return this;
     }
 
-    public MTable<T> withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MTable<T> withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/MTextArea.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTextArea.java
@@ -85,8 +85,10 @@ public class MTextArea extends TextArea {
         return this;
     }
 
-    public MTextArea withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MTextArea withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 
@@ -99,7 +101,7 @@ public class MTextArea extends TextArea {
         setRequired(required);
         return this;
     }
-    
+
     public MTextArea withRequiredError(String requiredError) {
         setRequiredError(requiredError);
         return this;

--- a/src/main/java/org/vaadin/viritin/fields/MTextField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTextField.java
@@ -152,8 +152,10 @@ public class MTextField extends TextField implements EagerValidateable {
         return this;
     }
 
-    public MTextField withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MTextField withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
@@ -376,8 +376,10 @@ public class MultiSelectTable<ET> extends CustomField<Collection> {
         return this;
     }
 
-    public MultiSelectTable<ET> withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MultiSelectTable<ET> withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
@@ -412,8 +412,10 @@ public class TypedSelect<T> extends CustomField {
         return this;
     }
 
-    public TypedSelect<T> withStyleName(String styleName) {
-        setStyleName(styleName);
+    public TypedSelect<T> withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/grid/MGrid.java
+++ b/src/main/java/org/vaadin/viritin/grid/MGrid.java
@@ -363,4 +363,11 @@ public class MGrid<T> extends Grid {
         return this;
     }
 
+    public MGrid<T> withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
+        return this;
+    }
+
 }

--- a/src/main/java/org/vaadin/viritin/label/Header.java
+++ b/src/main/java/org/vaadin/viritin/label/Header.java
@@ -100,8 +100,10 @@ public class Header extends Label {
         }
     }
 
-    public Header withStyleName(String styleName) {
-        setStyleName(styleName);
+    public Header withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MCssLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MCssLayout.java
@@ -40,8 +40,10 @@ public class MCssLayout extends CssLayout {
         return this;
     }
 
-    public MCssLayout withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MCssLayout withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MFormLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MFormLayout.java
@@ -51,8 +51,10 @@ public class MFormLayout extends FormLayout {
         return this;
     }
 
-    public MFormLayout withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MFormLayout withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MGridLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MGridLayout.java
@@ -87,8 +87,10 @@ public class MGridLayout extends GridLayout {
         return this;
     }
 
-    public MGridLayout withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MGridLayout withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
@@ -124,8 +124,10 @@ public class MHorizontalLayout extends HorizontalLayout {
         return this;
     }
 
-    public MHorizontalLayout withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MHorizontalLayout withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
@@ -118,8 +118,10 @@ public class MVerticalLayout extends VerticalLayout {
         return this;
     }
 
-    public MVerticalLayout withStyleName(String styleName) {
-        setStyleName(styleName);
+    public MVerticalLayout withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/layouts/MWindow.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MWindow.java
@@ -68,4 +68,11 @@ public class MWindow extends Window {
         setHeight(size.getHeight(), size.getHeightUnit());
         return this;
     }
+
+    public MWindow withStyleName(String... styleNames) {
+        for (String styleName : styleNames) {
+            addStyleName(styleName);
+        }
+        return this;
+    }
 }


### PR DESCRIPTION
Hi,

I've rewritten the withStyleName syntax to allow multiple StyleNames at once. Quite often you need to at more then one style for example button.
```java
new MButton(FontAwesome.Home, listener)
   .withStyleName(ValoTheme.BUTTON_BORDERLESS)
   .withStyleName(ValoTheme.BUTTON_QUIET);
// with was not working before my changes because you've called setStyleName instead of add that's why just BUTTON_QUIET was taken
// new version
new MButton(FontAwesome.Home, listener)
   .withStyleName(ValoTheme.BUTTON_BORDERLESS, ValoTheme.BUTTON_QUIET);
```

Best regards
Marten