### PR TITLE
added fallback to have support for read-only properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,10 +228,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
+                <executions>
+                	<execution>
+                		<id>default-compile</id>
+						<configuration>
+                    		<source>1.7</source>
+                    		<target>1.7</target>
+                		</configuration>
+                	</execution>
+                	<!-- see https://maven.apache.org/guides/mini/guide-default-execution-ids.html -->
+                	<execution>
+                		<id>default-testCompile</id>
+						<configuration>
+                    		<source>1.8</source>
+                    		<target>1.8</target>
+                		</configuration>
+                	</execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/test/java/org/vaadin/viritin/it/aspect/AspectAttributeTest.java
+++ b/src/test/java/org/vaadin/viritin/it/aspect/AspectAttributeTest.java
@@ -1,0 +1,30 @@
+package org.vaadin.viritin.it.aspect;
+
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.vaadin.addonhelpers.automated.AbstractWebDriverCase;
+import org.vaadin.addonhelpers.automated.VaadinConditions;
+
+public class AspectAttributeTest extends AbstractWebDriverCase {
+
+
+    public AspectAttributeTest() {
+        FirefoxProfile profile = new FirefoxProfile();
+        WebDriver webDriver = new FirefoxDriver(profile);
+        startBrowser(webDriver);
+    }
+
+    @Test
+    public void testLanguageByBrowser() throws InterruptedException {
+        driver.navigate().to(
+                "http://localhost:5678/"
+                        + MTableLazyLoadingWithEntityAspect.class.getCanonicalName());
+        new WebDriverWait(driver, 30).until(VaadinConditions
+                .ajaxCallsCompleted());
+
+        //Thread.sleep(10000);
+    }
+}

--- a/src/test/java/org/vaadin/viritin/it/aspect/AspectAttributeTest.java
+++ b/src/test/java/org/vaadin/viritin/it/aspect/AspectAttributeTest.java
@@ -1,3 +1,18 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.vaadin.viritin.it.aspect;
 
 import org.junit.Test;

--- a/src/test/java/org/vaadin/viritin/it/aspect/MTableLazyLoadingWithEntityAspect.java
+++ b/src/test/java/org/vaadin/viritin/it/aspect/MTableLazyLoadingWithEntityAspect.java
@@ -1,0 +1,62 @@
+package org.vaadin.viritin.it.aspect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.beanutils.BeanComparator;
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.viritin.LazyList;
+import org.vaadin.viritin.fields.MTable;
+import org.vaadin.viritin.testdomain.Service;
+import org.vaadin.viritin.testdomain.User;
+
+import com.vaadin.annotations.Theme;
+import com.vaadin.ui.Component;
+
+/**
+ * Test reading default methods
+ * Code borrowed from MTableLazyLoadingWithSorting
+ * @author Klaus Sausen
+ */
+@Theme("valo")
+public class MTableLazyLoadingWithEntityAspect extends AbstractTest {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public Component getTestComponent() {
+
+		final List<User> listOfPersons = 
+				Service
+				.getListOfPersons(1000).stream()
+				.map(person -> new User(person))
+				.collect(Collectors.toList());
+		
+		MTable<User> table = new MTable<>(
+				(firstRow, sortAscending, property) -> {
+					if (property != null) {
+						Collections.sort(listOfPersons, new BeanComparator<User>(
+								property));
+						if (!sortAscending) {
+							Collections.reverse(listOfPersons);
+						}
+					}
+					int last = firstRow + LazyList.DEFAULT_PAGE_SIZE;
+					if (last > listOfPersons.size()) {
+						last = listOfPersons.size();
+					}
+					return new ArrayList<User>(listOfPersons.subList(firstRow,
+							last));
+				},
+				() -> (int)Service.count()
+				)
+				.withProperties("localizedSalutation", "person.firstName", "person.lastName")
+				.withColumnHeaders("Salutation", "Forename", "Name")
+				.withFullWidth();
+
+		return table;
+	}
+
+}

--- a/src/test/java/org/vaadin/viritin/it/aspect/MTableLazyLoadingWithEntityAspect.java
+++ b/src/test/java/org/vaadin/viritin/it/aspect/MTableLazyLoadingWithEntityAspect.java
@@ -1,3 +1,18 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.vaadin.viritin.it.aspect;
 
 import java.util.ArrayList;

--- a/src/test/java/org/vaadin/viritin/testdomain/Service.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/Service.java
@@ -26,7 +26,7 @@ public class Service {
     }
 
     public static List<Group> getAvailableGroups() {
-        return new ArrayList(groups);
+        return new ArrayList<Group>(groups);
     }
 
     public static List<Person> getListOfPersons(int total) {

--- a/src/test/java/org/vaadin/viritin/testdomain/User.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/User.java
@@ -1,0 +1,47 @@
+package org.vaadin.viritin.testdomain;
+
+import java.util.Locale;
+
+import org.vaadin.viritin.testdomain.aspect.LocaleAware;
+import org.vaadin.viritin.testdomain.aspect.Salutation;
+
+/** 
+ * An example session user bean based on a person entity
+ * @author Klaus Sausen
+ */
+public class User 
+	implements LocaleAware, Salutation 
+{
+	private int personId;
+	private transient Person person;
+	
+	private Locale locale;
+	
+	public User() {
+		super();
+		locale = Locale.US;
+	}
+	
+	public User(Person personParameter) {
+		this();
+		person = personParameter;
+	}
+
+	public Locale getLocale() {
+		return locale;
+	}
+	
+	public void setLocale(Locale localeParam) {
+		locale = localeParam;
+	}
+	
+	public Person getPerson() {
+		if (person == null) {
+			person = new Person(); 
+			//e.g. if the session was serialized, reload the person by id 
+			person.setId(personId);
+		}
+		return person;
+	}
+	
+}

--- a/src/test/java/org/vaadin/viritin/testdomain/User.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/User.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Klaus Sausen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.viritin.testdomain;
 
 import java.util.Locale;
@@ -7,7 +22,6 @@ import org.vaadin.viritin.testdomain.aspect.Salutation;
 
 /** 
  * An example session user bean based on a person entity
- * @author Klaus Sausen
  */
 public class User 
 	implements LocaleAware, Salutation 

--- a/src/test/java/org/vaadin/viritin/testdomain/aspect/LocaleAware.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/aspect/LocaleAware.java
@@ -1,0 +1,12 @@
+package org.vaadin.viritin.testdomain.aspect;
+
+import java.util.Locale;
+
+/**
+ * Locale aware objects, such as the logged-in user, etc.
+ * 
+ */
+public interface LocaleAware {
+
+	Locale getLocale();
+}

--- a/src/test/java/org/vaadin/viritin/testdomain/aspect/LocaleAware.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/aspect/LocaleAware.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2016 Klaus Sausen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.vaadin.viritin.testdomain.aspect;
 
 import java.util.Locale;
 
 /**
  * Locale aware objects, such as the logged-in user, etc.
- * 
  */
 public interface LocaleAware {
 

--- a/src/test/java/org/vaadin/viritin/testdomain/aspect/Salutation.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/aspect/Salutation.java
@@ -1,0 +1,38 @@
+package org.vaadin.viritin.testdomain.aspect;
+
+import java.util.Locale;
+
+
+/**
+ * This is a possibility how to add a read-only aspect with 
+ * Java 8 default methods to several entities at once 
+ * by only implementing the interface.
+ * If the test class {@link org.vaadin.viritin.testdomain.Person} 
+ * had a gender the salutation could even be done gender specific.
+ * 
+ * @author Klaus Sausen
+ */
+public interface Salutation extends LocaleAware {
+
+	/**
+	 * (Usually the texts are in external resources)
+	 * @return a localized salutation
+	 */
+	default String getLocalizedSalutation() {
+		
+		Locale locale = getLocale();
+		if (locale == null) {
+			return null;
+		}
+		String language = locale.getLanguage();
+		if (language.equals(Locale.ENGLISH.getLanguage())) {
+			return "Dear {0},";
+		} 
+		else if (language.equals(Locale.FRANCE.getLanguage())) {
+			return "Cher {0},";
+		}
+		return "{0},";
+	
+	}
+	
+}

--- a/src/test/java/org/vaadin/viritin/testdomain/aspect/Salutation.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/aspect/Salutation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Klaus Sausen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.vaadin.viritin.testdomain.aspect;
 
 import java.util.Locale;


### PR DESCRIPTION
Hello Matti,
my proposal to have support for default methods added to the entities.
E.g.
   
    public interface WordLength {
	  String getWord();
	  default int getWordLength() {
		String w = getWord();
		return w != null ? w.length() : 0;
	  }
    }

One can then bind the readonly field as well. I don't know whether there are other components where this feature also makes sense.
Though this is actually a work around since commons beanutils doesn't support it.
hth