### PR TITLE
GeneratedPropertyListContainer implementation

### DIFF
--- a/src/main/java/org/vaadin/viritin/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/GeneratedPropertyListContainer.java
@@ -1,0 +1,179 @@
+package org.vaadin.viritin;
+
+import com.google.gwt.thirdparty.guava.common.collect.Sets;
+import com.vaadin.data.Item;
+import com.vaadin.data.Property;
+import com.vaadin.data.util.PropertyValueGenerator;
+
+import java.util.*;
+
+public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
+
+    private final Map<Object, PropertyValueGenerator<?>> propertyGenerators = new HashMap();
+
+    /**
+     * Property implementation for generated properties
+     */
+    protected static class GeneratedProperty<T> implements Property<T>  {
+
+        private Item item;
+        private Object itemId;
+        private Object propertyId;
+        private PropertyValueGenerator<T> generator;
+
+        public GeneratedProperty(Item item, Object propertyId, Object itemId,
+                                 PropertyValueGenerator<T> generator) {
+            this.item = item;
+            this.itemId = itemId;
+            this.propertyId = propertyId;
+            this.generator = generator;
+        }
+
+        @Override
+        public T getValue() {
+            return generator.getValue(item, itemId, propertyId);
+        }
+
+        @Override
+        public void setValue(T newValue) throws ReadOnlyException {
+            throw new ReadOnlyException("Generated properties are read only");
+        }
+
+        @Override
+        public Class<? extends T> getType() {
+            return generator.getType();
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return true;
+        }
+
+        @Override
+        public void setReadOnly(boolean newStatus) {
+            if (newStatus) {
+                // No-op
+                return;
+            }
+            throw new UnsupportedOperationException(
+                    "Generated properties are read only");
+        }
+    }
+
+    /**
+     * Item implementation for generated properties.
+     */
+    protected class GeneratedPropertyItem implements Item {
+
+        private Item wrappedItem;
+        private Object itemId;
+
+        protected GeneratedPropertyItem(Object itemId, Item item) {
+            this.itemId = itemId;
+            wrappedItem = item;
+        }
+
+        @Override
+        public Property getItemProperty(Object id) {
+            if (propertyGenerators.containsKey(id)) {
+                return createProperty(wrappedItem, id, itemId,
+                        propertyGenerators.get(id));
+            }
+            return wrappedItem.getItemProperty(id);
+        }
+
+        @Override
+        public Collection<?> getItemPropertyIds() {
+            Set<?> wrappedProperties = new HashSet<>(wrappedItem.getItemPropertyIds());
+            return Sets.union(
+                    wrappedProperties,
+                    propertyGenerators.keySet());
+        }
+
+        @Override
+        public boolean addItemProperty(Object id, Property property)
+                throws UnsupportedOperationException {
+            throw new UnsupportedOperationException(
+                    "GeneratedPropertyItem does not support adding properties");
+        }
+
+        @Override
+        public boolean removeItemProperty(Object id)
+                throws UnsupportedOperationException {
+            throw new UnsupportedOperationException(
+                    "GeneratedPropertyItem does not support removing properties");
+        }
+
+        /**
+         * Tests if the given object is the same as the this object. Two Items
+         * from the same container with the same ID are equal.
+         *
+         * @param obj
+         *            an object to compare with this object
+         * @return <code>true</code> if the given object is the same as this
+         *         object, <code>false</code> if not
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+
+            if (obj == null
+                    || !obj.getClass().equals(GeneratedPropertyItem.class)) {
+                return false;
+            }
+            final GeneratedPropertyItem li = (GeneratedPropertyItem) obj;
+            return getContainer() == li.getContainer()
+                    && itemId.equals(li.itemId);
+        }
+
+        @Override
+        public int hashCode() {
+            return itemId.hashCode();
+        }
+
+        private GeneratedPropertyListContainer getContainer() {
+            return GeneratedPropertyListContainer.this;
+        }
+    }
+
+    public GeneratedPropertyListContainer(Class<T> type, String[] properties) {
+        super(type);
+        setContainerPropertyIds(properties);
+    }
+
+    public void addGeneratedProperty(Object propertyId, PropertyValueGenerator<?> generator) {
+        propertyGenerators.put(propertyId, generator);
+        fireContainerPropertySetChange();
+    }
+
+    @Override
+    public Class<?> getType(Object propertyId) {
+        if (propertyGenerators.containsKey(propertyId)) {
+            return propertyGenerators.get(propertyId).getType();
+        }
+        return super.getType(propertyId);
+    }
+
+    @Override
+    public Item getItem(Object itemId) {
+        if (itemId == null) {
+            return null;
+        }
+        Item item = super.getItem(itemId);
+        return createGeneratedPropertyItem(itemId, item);
+    }
+
+    private <T> Property<T> createProperty(final Item item,
+                                           final Object propertyId, final Object itemId,
+                                           final PropertyValueGenerator<T> generator) {
+        return new GeneratedProperty<T>(item, propertyId, itemId, generator);
+    }
+
+    private Item createGeneratedPropertyItem(final Object itemId,
+                                             final Item item) {
+        return new GeneratedPropertyItem(itemId, item);
+    }
+
+}

--- a/src/main/java/org/vaadin/viritin/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/GeneratedPropertyListContainer.java
@@ -7,9 +7,14 @@ import com.vaadin.data.util.PropertyValueGenerator;
 
 import java.util.*;
 
+/**
+ *
+ * @author Shabak Nikolay (nikolay.shabak@gmail.com)
+ * @param <T> the entity type listed in the consumer of the container, Vaadin Grid
+ */
 public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
 
-    private final Map<Object, PropertyValueGenerator<?>> propertyGenerators = new HashMap();
+    private final Map<String, PropertyValueGenerator<?>> propertyGenerators = new HashMap();
 
     /**
      * Property implementation for generated properties
@@ -138,12 +143,16 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
         }
     }
 
-    public GeneratedPropertyListContainer(Class<T> type, String[] properties) {
+    public GeneratedPropertyListContainer(Class<T> type) {
+        super(type);
+    }
+
+    public GeneratedPropertyListContainer(Class<T> type, String... properties) {
         super(type);
         setContainerPropertyIds(properties);
     }
 
-    public void addGeneratedProperty(Object propertyId, PropertyValueGenerator<?> generator) {
+    public void addGeneratedProperty(String propertyId, PropertyValueGenerator<?> generator) {
         propertyGenerators.put(propertyId, generator);
         fireContainerPropertySetChange();
     }

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -174,6 +174,14 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
         fireContainerPropertySetChange();
     }
 
+    public void addGeneratedProperty(String propertyId,
+                                     StringPropertyValueGenerator.ValueGenerator<T> generator) {
+        StringPropertyValueGenerator<T> lambdaPropertyValueGenerator =
+                new StringPropertyValueGenerator<>(type, generator);
+        propertyGenerators.put(propertyId, lambdaPropertyValueGenerator);
+        fireContainerPropertySetChange();
+    }
+
     @Override
     public Class<?> getType(Object propertyId) {
         if (propertyGenerators.containsKey(propertyId)) {

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -1,20 +1,23 @@
-package org.vaadin.viritin;
+package org.vaadin.viritin.grid;
 
 import com.google.gwt.thirdparty.guava.common.collect.Sets;
 import com.vaadin.data.Item;
 import com.vaadin.data.Property;
 import com.vaadin.data.util.PropertyValueGenerator;
+import org.vaadin.viritin.ListContainer;
 
 import java.util.*;
 
 /**
  *
  * @author Shabak Nikolay (nikolay.shabak@gmail.com)
+ * @since 23.04.2016
  * @param <T> the entity type listed in the consumer of the container, Vaadin Grid
  */
 public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
 
     private final Map<String, PropertyValueGenerator<?>> propertyGenerators = new HashMap();
+    protected final Class<T> type;
 
     /**
      * Property implementation for generated properties
@@ -145,15 +148,29 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
 
     public GeneratedPropertyListContainer(Class<T> type) {
         super(type);
+        this.type = type;
     }
 
     public GeneratedPropertyListContainer(Class<T> type, String... properties) {
         super(type);
+        this.type = type;
         setContainerPropertyIds(properties);
     }
 
     public void addGeneratedProperty(String propertyId, PropertyValueGenerator<?> generator) {
         propertyGenerators.put(propertyId, generator);
+        fireContainerPropertySetChange();
+    }
+
+    /**
+     * @param <P> the presentation type, displays the generated value
+     */
+    public <P> void addGeneratedProperty(String propertyId,
+                                         Class<P> presentationType,
+                                         LambdaPropertyValueGenerator.ValueGenerator<T, P> generator) {
+        LambdaPropertyValueGenerator<T, P> lambdaPropertyValueGenerator =
+                new LambdaPropertyValueGenerator<>(type, presentationType, generator);
+        propertyGenerators.put(propertyId, lambdaPropertyValueGenerator);
         fireContainerPropertySetChange();
     }
 

--- a/src/main/java/org/vaadin/viritin/grid/LambdaPropertyValueGenerator.java
+++ b/src/main/java/org/vaadin/viritin/grid/LambdaPropertyValueGenerator.java
@@ -20,9 +20,9 @@ import java.io.Serializable;
  */
 public class LambdaPropertyValueGenerator<M, P> extends PropertyValueGenerator<P> {
 
-    Class<M> modelType;
-    Class<P> presentationType;
-    ValueGenerator<M, P> valueGenerator;
+    protected Class<M> modelType;
+    protected Class<P> presentationType;
+    protected ValueGenerator<M, P> valueGenerator;
 
     public LambdaPropertyValueGenerator(Class<M> modelType,
                                         Class<P> presentationType,

--- a/src/main/java/org/vaadin/viritin/grid/LambdaPropertyValueGenerator.java
+++ b/src/main/java/org/vaadin/viritin/grid/LambdaPropertyValueGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016, i-Free. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package org.vaadin.viritin.grid;
+
+import com.vaadin.data.Item;
+import com.vaadin.data.util.PropertyValueGenerator;
+import org.vaadin.viritin.ListContainer;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author datenhahn (http://datenhahn.de)
+ * @since 23.04.2016
+ * @param <M> the entity type listed in the consumer of the generator's container, Vaadin Grid
+ * @param <P> the presentation type, displays the generated value
+ */
+public class LambdaPropertyValueGenerator<M, P> extends PropertyValueGenerator<P> {
+
+    Class<M> modelType;
+    Class<P> presentationType;
+    ValueGenerator<M, P> valueGenerator;
+
+    public LambdaPropertyValueGenerator(Class<M> modelType,
+                                        Class<P> presentationType,
+                                        ValueGenerator<M, P> valueGenerator) {
+        this.modelType = modelType;
+        this.presentationType = presentationType;
+        this.valueGenerator = valueGenerator;
+    }
+
+    @Override
+    public P getValue(Item item, Object itemId, Object propertyId) {
+        return valueGenerator.getValue((M) ((ListContainer.DynaBeanItem) item).getBean());
+    }
+
+    @Override
+    public Class<P> getType() {
+        return presentationType;
+    }
+
+    public interface ValueGenerator<M, P> extends Serializable {
+        P getValue(M bean);
+    }
+}

--- a/src/main/java/org/vaadin/viritin/grid/MGrid.java
+++ b/src/main/java/org/vaadin/viritin/grid/MGrid.java
@@ -10,11 +10,9 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.vaadin.viritin.GeneratedPropertyListContainer;
 import org.vaadin.viritin.LazyList;
 import org.vaadin.viritin.ListContainer;
 import org.vaadin.viritin.SortableLazyList;
-import org.vaadin.viritin.fields.MTable;
 import org.vaadin.viritin.grid.utils.GridUtils;
 
 import com.vaadin.data.util.PropertyValueGenerator;
@@ -153,8 +151,21 @@ public class MGrid<T> extends Grid {
         return this;
     }
 
-    public MGrid<T> withGeneratedColumn(String columnId,
-                                        final PropertyValueGenerator<?> columnGenerator) {
+    public <P> MGrid<T> withGeneratedColumn(String columnId,
+                                            Class<P> presentationType,
+                                            LambdaPropertyValueGenerator.ValueGenerator<T, P> generator) {
+        LambdaPropertyValueGenerator<T, P> lambdaPropertyValueGenerator =
+                new LambdaPropertyValueGenerator<>(typeOfRows, presentationType, generator);
+        addGeneratedColumn(columnId, lambdaPropertyValueGenerator);
+        return this;
+    }
+
+    public MGrid<T> withGeneratedColumn(String columnId, final PropertyValueGenerator<?> columnGenerator) {
+        addGeneratedColumn(columnId, columnGenerator);
+        return this;
+    }
+
+    private void addGeneratedColumn(String columnId, final PropertyValueGenerator<?> columnGenerator) {
         Container.Indexed container = getContainerDataSource();
         GeneratedPropertyListContainer gplc;
         if (container instanceof GeneratedPropertyListContainer) {
@@ -164,7 +175,6 @@ public class MGrid<T> extends Grid {
             setContainerDataSource(gplc);
         }
         gplc.addGeneratedProperty(columnId, columnGenerator);
-        return this;
     }
 
     public MGrid<T> withFullWidth() {

--- a/src/main/java/org/vaadin/viritin/grid/MGrid.java
+++ b/src/main/java/org/vaadin/viritin/grid/MGrid.java
@@ -10,11 +10,14 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.vaadin.viritin.GeneratedPropertyListContainer;
 import org.vaadin.viritin.LazyList;
 import org.vaadin.viritin.ListContainer;
 import org.vaadin.viritin.SortableLazyList;
+import org.vaadin.viritin.fields.MTable;
 import org.vaadin.viritin.grid.utils.GridUtils;
 
+import com.vaadin.data.util.PropertyValueGenerator;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.fieldgroup.FieldGroup;
@@ -29,6 +32,8 @@ import com.vaadin.ui.Grid;
  */
 public class MGrid<T> extends Grid {
 
+    private Class<T> typeOfRows;
+
     public MGrid() {
     }
 
@@ -39,6 +44,7 @@ public class MGrid<T> extends Grid {
      */
     public MGrid(Class<T> typeOfRows) {
         setContainerDataSource(new ListContainer(typeOfRows));
+        this.typeOfRows = typeOfRows;
     }
 
     /**
@@ -143,7 +149,26 @@ public class MGrid<T> extends Grid {
     }
 
     public MGrid<T> setRows(T... rows) {
-        setContainerDataSource(new ListContainer(Arrays.asList(rows)));
+        setRows(Arrays.asList(rows));
+        return this;
+    }
+
+    public MGrid<T> withGeneratedColumn(String columnId,
+                                        final PropertyValueGenerator<?> columnGenerator) {
+        Container.Indexed container = getContainerDataSource();
+        GeneratedPropertyListContainer gplc;
+        if (container instanceof GeneratedPropertyListContainer) {
+            gplc = (GeneratedPropertyListContainer) container;
+        } else {
+            gplc = new GeneratedPropertyListContainer(typeOfRows);
+            setContainerDataSource(gplc);
+        }
+        gplc.addGeneratedProperty(columnId, columnGenerator);
+        return this;
+    }
+
+    public MGrid<T> withFullWidth() {
+        setWidth(100, Unit.PERCENTAGE);
         return this;
     }
 

--- a/src/main/java/org/vaadin/viritin/grid/MGrid.java
+++ b/src/main/java/org/vaadin/viritin/grid/MGrid.java
@@ -160,6 +160,13 @@ public class MGrid<T> extends Grid {
         return this;
     }
 
+    public MGrid<T> withGeneratedColumn(String columnId, StringPropertyValueGenerator.ValueGenerator<T> generator) {
+        StringPropertyValueGenerator<T> lambdaPropertyValueGenerator =
+                new StringPropertyValueGenerator<>(typeOfRows, generator);
+        addGeneratedColumn(columnId, lambdaPropertyValueGenerator);
+        return this;
+    }
+
     public MGrid<T> withGeneratedColumn(String columnId, final PropertyValueGenerator<?> columnGenerator) {
         addGeneratedColumn(columnId, columnGenerator);
         return this;

--- a/src/main/java/org/vaadin/viritin/grid/StringPropertyValueGenerator.java
+++ b/src/main/java/org/vaadin/viritin/grid/StringPropertyValueGenerator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016, i-Free. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+
+package org.vaadin.viritin.grid;
+
+import com.vaadin.data.Item;
+import com.vaadin.data.util.PropertyValueGenerator;
+import org.vaadin.viritin.ListContainer;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author datenhahn (http://datenhahn.de)
+ * @since 23.04.2016
+ * @param <M> the entity type listed in the consumer of the generator's container, Vaadin Grid
+ */
+public class StringPropertyValueGenerator<M> extends LambdaPropertyValueGenerator<M, String> {
+
+    public StringPropertyValueGenerator(Class<M> modelType, ValueGenerator<M> valueGenerator) {
+        super(modelType, String.class, valueGenerator);
+    }
+
+    @Override
+    public String getValue(Item item, Object itemId, Object propertyId) {
+        return valueGenerator.getValue((M) ((ListContainer.DynaBeanItem) item).getBean());
+    }
+
+    public interface ValueGenerator<M> extends LambdaPropertyValueGenerator.ValueGenerator<M, String> {
+        String getValue(M bean);
+    }
+}

--- a/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
+++ b/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
@@ -1,0 +1,83 @@
+package org.vaadin.viritin.it;
+
+import com.vaadin.annotations.Theme;
+import com.vaadin.data.Item;
+import com.vaadin.data.util.ObjectProperty;
+import com.vaadin.data.util.PropertyValueGenerator;
+import com.vaadin.ui.Component;
+import org.jsoup.safety.Whitelist;
+import org.junit.Test;
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.viritin.fields.LabelField;
+import org.vaadin.viritin.grid.GeneratedPropertyListContainer;
+import org.vaadin.viritin.grid.MGrid;
+import org.vaadin.viritin.label.RichText;
+import org.vaadin.viritin.layouts.MVerticalLayout;
+import org.vaadin.viritin.testdomain.Address;
+import org.vaadin.viritin.testdomain.Person;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ *
+ * @author Matti Tahvonen
+ */
+@Theme("valo")
+public class GeneratedPropertyListContainerExample extends AbstractTest {
+
+    private MGrid<Person> fashionableApiGrid = new MGrid<>(Person.class)
+            .withGeneratedColumn("fullname", p -> p.getFirstName() + " " + p.getLastName())
+            .withGeneratedColumn("groupnumber", Integer.class, p -> p.getGroups() != null ? p.getGroups().size() : 0)
+            .withGeneratedColumn("details", new DetailsGenerator())
+            .withProperties("id", "name", "email", "fullname", "groupnumber", "details")
+            .withFullWidth();
+
+    private MGrid<Person> legacyApiGrid = new MGrid<>();
+
+    @Override
+    public Component getTestComponent() {
+
+        GeneratedPropertyListContainer<Person> container = new
+                GeneratedPropertyListContainer(Person.class,
+                "id", "name", "email", "fullname", "groupnumber", "details");
+        container.addGeneratedProperty("fullname", p -> p.getFirstName() + " " + p.getLastName());
+        container.addGeneratedProperty("groupnumber", Integer.class, p -> p.getGroups() != null ? p.getGroups().size() : 0);
+        container.addGeneratedProperty("details", new DetailsGenerator());
+        legacyApiGrid.setContainerDataSource(container);
+        legacyApiGrid.getColumn("details").setHeaderCaption("Details");
+        legacyApiGrid.setSizeFull();
+
+        return new MVerticalLayout(fashionableApiGrid, legacyApiGrid);
+    }
+
+    public class DetailsGenerator extends PropertyValueGenerator<String> {
+
+        @Override
+        public String getValue(Item item, Object itemId, Object propertyId) {
+            Person p = (Person)itemId;
+            StringBuilder displayValue = new StringBuilder();
+            List<Address> addresses = p.getAddresses();
+            if (addresses != null && !addresses.isEmpty()) {
+                displayValue.append("Addresses: ");
+                for (Address address : addresses) {
+                    if (address == null) continue;
+                    displayValue.append(address.getZipCode());
+                    displayValue.append("; ");
+                    displayValue.append(address.getCity());
+                    displayValue.append("; ");
+                    displayValue.append(address.getStreet());
+                }
+            }
+            return displayValue.toString();
+        }
+
+        @Override
+        public Class<String> getType() {
+            return String.class;
+        }
+    }
+
+
+}


### PR DESCRIPTION
There is a list data container supporting generated columns. This is a clone of original GeneratedPropertyContainer from Vaadin. The implementation contains copy of some code of inner classes of GeneratedPropertyContainer, mostly because it has a protected access. I use Vaadin Grid a lot in my project, so I had to implement it for MGrid, because I needed the paging feature and generated columns as well. So I'd like to share id with community. Also I'd like to implement next desirable features such as filtering by generated columns values and removing properties dynamically. 

This is an example application based on viritin example: http://shabak.ru:9292/generated-property-list-container-example/

This is a use case: https://github.com/shabak/spring-data-vaadin-crud/blob/master/src/main/java/crud/vaadin/MainUI.java

Thanks.