### PR TITLE
MBeanFieldGroup.configureMaddonDefaults: interpolate error message

### DIFF
--- a/src/test/java/org/vaadin/viritin/MBeanFieldGroupTest.java
+++ b/src/test/java/org/vaadin/viritin/MBeanFieldGroupTest.java
@@ -1,0 +1,91 @@
+package org.vaadin.viritin;
+
+import com.vaadin.ui.AbstractField;
+import com.vaadin.ui.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.vaadin.viritin.testdomain.Address;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by marco on 06/05/16.
+ */
+public class MBeanFieldGroupTest {
+
+    private Locale defaultLocale;
+
+    @Before
+    public void storeDefaultLocale() {
+        defaultLocale = Locale.getDefault();
+    }
+
+    @After
+    public void restoreDefaultLocale() {
+        Locale.setDefault(defaultLocale);
+    }
+
+    @Test
+    public void notNullAnnotatedFieldsShouldHaveInterpolatedErrorMessage() {
+        // Force en_US as default for test purpose
+        Locale.setDefault(Locale.US);
+
+        MBeanFieldGroup fieldGroup = new MBeanFieldGroup<Tester>(Tester.class);
+        Field<?> defaultMessageField = fieldGroup.buildAndBind("defaultMessage");
+        Field<?> customMessageKeyField = fieldGroup.buildAndBind("customMessageKey");
+        Field<?> customMessageField = fieldGroup.buildAndBind("customMessage");
+        fieldGroup.configureMaddonDefaults();
+        assertThat(defaultMessageField.getRequiredError(), equalTo("may not be null"));
+        assertThat(customMessageKeyField.getRequiredError(), equalTo("Emails must match!"));
+        assertThat(customMessageField.getRequiredError(), equalTo("Custom message"));
+    }
+
+    @Test
+    public void notNullAnnotatedFieldsShouldHaveInterpolatedErrorMessageWithLocale() {
+        Locale locale = Locale.ITALIAN;
+        MBeanFieldGroup fieldGroup = new MBeanFieldGroup<Tester>(Tester.class);
+        Field<?> defaultMessageField = fieldGroup.buildAndBind("defaultMessage");
+        Field<?> customMessageKeyField = fieldGroup.buildAndBind("customMessageKey");
+        Field<?> customMessageField = fieldGroup.buildAndBind("customMessage");
+        withLocale(locale, defaultMessageField, customMessageField, customMessageKeyField);
+        fieldGroup.configureMaddonDefaults();
+        assertThat(defaultMessageField.getRequiredError(), equalTo("Non deve essere nullo"));
+        assertThat(customMessageKeyField.getRequiredError(), equalTo("Gli indirizzi email devono corrispondere!"));
+        assertThat(customMessageField.getRequiredError(), equalTo("Custom message"));
+    }
+
+    private void withLocale(Locale locale, Field<?>... fields) {
+        Arrays.stream(fields).map(AbstractField.class::cast).forEach(f -> f.setLocale(locale));
+    }
+
+    public static class Tester {
+
+        @NotNull
+        private String defaultMessage;
+
+        @NotNull(message = "{YourMsgKey}")
+        private String customMessageKey;
+
+        @NotNull(message = "Custom message")
+        private String customMessage;
+
+        public String getCustomMessage() {
+            return customMessage;
+        }
+
+        public String getCustomMessageKey() {
+            return customMessageKey;
+        }
+
+        public String getDefaultMessage() {
+            return defaultMessage;
+        }
+    }
+}

--- a/src/test/java/org/vaadin/viritin/it/MBeanFieldGroupRequiredErrorMessage.java
+++ b/src/test/java/org/vaadin/viritin/it/MBeanFieldGroupRequiredErrorMessage.java
@@ -1,0 +1,28 @@
+package org.vaadin.viritin.it;
+
+import com.vaadin.annotations.Theme;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.TextField;
+import org.vaadin.addonhelpers.AbstractTest;
+import org.vaadin.viritin.BeanBinder;
+import org.vaadin.viritin.layouts.MVerticalLayout;
+import org.vaadin.viritin.testdomain.Address;
+
+/**
+ * Created by marco on 07/05/16.
+ */
+@Theme("valo")
+public class MBeanFieldGroupRequiredErrorMessage extends AbstractTest {
+
+    private TextField street ;
+
+
+    public Component getTestComponent() {
+        street = new TextField();
+        street.setLocale(getLocale());
+        street.setId("txtStreet");
+        BeanBinder.bind(new Address(),this);
+        return new MVerticalLayout(street);
+    }
+}

--- a/src/test/java/org/vaadin/viritin/it/MBeanFieldGroupRequiredErrorMessageTest.java
+++ b/src/test/java/org/vaadin/viritin/it/MBeanFieldGroupRequiredErrorMessageTest.java
@@ -1,0 +1,66 @@
+package org.vaadin.viritin.it;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.vaadin.addonhelpers.automated.AbstractWebDriverCase;
+import org.vaadin.addonhelpers.automated.VaadinConditions;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by marco on 07/05/16.
+ */
+@RunWith(Parameterized.class)
+public class MBeanFieldGroupRequiredErrorMessageTest extends AbstractWebDriverCase {
+
+    @Parameterized.Parameters
+    public static Collection languages() {
+        return Arrays.asList(new Object[][] {
+            { "en", "may not be null" },
+            { "it", "Non deve essere nullo" },
+        });
+
+    }
+
+    private final String expectedMessage;
+
+
+    public MBeanFieldGroupRequiredErrorMessageTest(String language, String expectedMessage) {
+        this.expectedMessage = expectedMessage;
+        FirefoxProfile profile = new FirefoxProfile();
+        profile.setPreference("intl.accept_languages", language);
+        WebDriver webDriver = new FirefoxDriver(profile);
+        startBrowser(webDriver);
+    }
+
+    @Test
+    public void testErrorMessageForNonNullAnnotatedComponent() throws InterruptedException {
+        driver.navigate().to(
+            "http://localhost:5678/"
+                + MBeanFieldGroupRequiredErrorMessage.class.getCanonicalName());
+        new WebDriverWait(driver, 30).until(VaadinConditions
+            .ajaxCallsCompleted());
+
+        WebElement txtField = driver.findElement(By.id("txtStreet"));
+        Actions toolAct = new Actions(driver);
+        toolAct.moveToElement(txtField).build().perform();
+        Thread.sleep(1000);
+        WebElement toolTipElement = driver.findElement(By.cssSelector(".v-app.v-overlay-container > .v-tooltip > .popupContent .v-errormessage > div > div"));
+
+        assertThat(toolTipElement.getText(), is(expectedMessage));
+    }
+
+}

--- a/src/test/resources/ValidationMessages_it.properties
+++ b/src/test/resources/ValidationMessages_it.properties
@@ -1,0 +1,2 @@
+YourMsgKey=Gli indirizzi email devono corrispondere!
+javax.validation.constraints.NotNull.message=Non deve essere nullo


### PR DESCRIPTION
When invoking MBeanFieldGroup.configureMaddonDefaults fields annotated with NonNull annotation are set as required and the error message from annotation is set as  Field.setRequiredError but the message is set as is resulting in many cases in tooltip showing the message key.

The fix interpolates the error message got from the annotation before invoking Field.setRequiredError