### PR TITLE
Added MView and MNavigator

### DIFF
--- a/src/main/java/org/vaadin/viritin/navigator/MNavigator.java
+++ b/src/main/java/org/vaadin/viritin/navigator/MNavigator.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016 Matti Tahvonen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.vaadin.viritin.navigator;
+
+import com.vaadin.navigator.NavigationStateManager;
+import com.vaadin.navigator.Navigator;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener;
+import com.vaadin.navigator.ViewDisplay;
+import com.vaadin.ui.ComponentContainer;
+import com.vaadin.ui.SingleComponentContainer;
+import com.vaadin.ui.UI;
+
+/**
+ * A navigator utility that allows switching of views in a part of an application. 
+ * 
+ * <p>
+ * This is a drop-in replacement for {@link com.vaadin.navigator.Navigator}. 
+ * It uses an enhanced {@code View} implementation, called {@link MView}. It is 
+ * still possible to use old-style {@code View}s with {@code MNavigator} but then
+ * there is no gain to using {@code MNavigator} over {@code Navigator}.
+ * 
+ * 
+ * 
+ */
+public class MNavigator extends Navigator {
+
+    /**
+     * Creates a navigator that is tracking the active view using URI fragments
+     * of the {@link com.vaadin.server.Page} containing the given UI and
+     * replacing the contents of a
+     * {@link com.vaadin.ui.ComponentContainer} with the
+     * active view.
+     * 
+     * <p>
+     * This constructor is exactly similar to 
+     * {@link com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.ui.ComponentContainer)}
+     * 
+     * @see com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.ui.ComponentContainer)
+     */
+    public MNavigator(UI ui, ComponentContainer container) {
+        super(ui, container);
+    }
+
+    /**
+     * Creates a navigator. 
+     * 
+     * <p>
+     * This constructor is exactly similar to 
+     * {@link com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.navigator.NavigationStateManager, com.vaadin.navigator.ViewDisplay)}
+     * 
+     * @see com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.navigator.NavigationStateManager, com.vaadin.navigator.ViewDisplay)
+     */
+    public MNavigator(UI ui, NavigationStateManager stateManager, ViewDisplay display) {
+        super(ui, stateManager, display);
+    }
+
+    /**
+     * Creates a navigator that is tracking the active view using URI fragments
+     * of the {@link com.vaadin.server.Page} containing the given UI and
+     * replacing the contents of a {@link com.vaadin.ui.SingleComponentContainer} with
+     * the active view.
+     *
+     * <p>
+     * This constructor is exactly similar to 
+     * {@link com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.ui.SingleComponentContainer)}
+     * 
+     * @see com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.ui.SingleComponentContainer) 
+     */
+    public MNavigator(UI ui, SingleComponentContainer container) {
+        super(ui, container);
+    }
+
+    /**
+     * Creates a navigator that is tracking the active view using URI fragments
+     * of the {@link com.vaadin.server.Page} containing the given UI.
+     *
+     * <p>
+     * This constructor is exactly similar to 
+     * {@link com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.navigator.ViewDisplay)}
+     * 
+     * @see com.vaadin.navigator.Navigator#Navigator(com.vaadin.ui.UI, com.vaadin.navigator.ViewDisplay) 
+     */
+    public MNavigator(UI ui, ViewDisplay display) {
+        super(ui, display);
+    }
+
+    
+    /**
+     * Creates a navigator. This method is for use by dependency injection
+     * frameworks etc. and must be followed by a call to
+     * {@link #init(UI, NavigationStateManager, ViewDisplay) init()} before use.
+     *
+     * @since 7.6
+     */
+    protected MNavigator() {
+    }
+    
+
+
+    /**
+     * {@inheritDoc}
+     * Generally shouldn't be called directly.
+     */
+    @Override
+    protected void init(UI ui, NavigationStateManager stateManager, ViewDisplay display) {
+        super.init(ui, stateManager, display); 
+        addViewChangeListener(new MViewChangeListener());
+    }
+    
+    // ViewChangeListener which actually does the work of propagating the
+    // beforeViewChange and afterViewChange into the relevant views.
+    // The listener exists for the life-time of the navigator. It never
+    // gets unregistered.
+    private static class MViewChangeListener implements ViewChangeListener {
+
+        @Override
+        public boolean beforeViewChange(ViewChangeListener.ViewChangeEvent event) {
+            View oldView = event.getOldView();
+            if (oldView != null && oldView instanceof MView) {
+                return ((MView)oldView).beforeViewChange(event);
+            }
+            return true;
+        }
+
+        @Override
+        public void afterViewChange(ViewChangeListener.ViewChangeEvent event) {
+            View oldView = event.getOldView();
+            if (oldView != null && oldView instanceof MView) {
+                ((MView)oldView).afterViewChange(event);
+            }
+        }
+    }
+    
+}
+    
+

--- a/src/main/java/org/vaadin/viritin/navigator/MView.java
+++ b/src/main/java/org/vaadin/viritin/navigator/MView.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Matti Tahvonen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.vaadin.viritin.navigator;
+
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener;
+
+/**
+ * Interface for all views controlled by the {@code MNavigator}. 
+ * Each view added to the navigator must implement this interface. 
+ * Typically, a view is a {@link com.vaadin.ui.Component}.
+ * 
+ * <p>
+ * This is a drop-in replacement for {@link com.vaadin.navigator.View}
+ * which has been enhanced to know not only when a view is entered <i>into</i>
+ * (the {@code enter()} method), but also when a view is <i>exiting</i>
+ * (the {@code beforeViewChange()} and {@code afterViewChange()} methods).
+ * 
+ * <p>
+ * This class can be used with both {@code MNavigator} and {@code Navigator}.
+ * However, in order for the {@code beforeViewChange()} and {@code afterViewChange()}
+ * methods to actually be invoked the view <i>must</i> be used with {@code MNavigator}.
+ */
+public interface MView extends View {
+
+    /**
+     * Invoked before the view is changed.
+     * 
+     * 
+     * <p>
+     * By returning {@code false} from this method the view change is 
+     * denied. More information in {@link com.vaadin.navigator.ViewChangeListener#beforeViewChange(com.vaadin.navigator.ViewChangeListener.ViewChangeEvent)}.
+     *
+     * 
+     * @param event view change event
+     * @return true if the view change should be allowed or this listener does
+     *    not care about the view change, false to block the change
+     * 
+     * @see com.vaadin.navigator.ViewChangeListener#beforeViewChange(com.vaadin.navigator.ViewChangeListener.ViewChangeEvent)
+     * 
+     */
+    public boolean beforeViewChange(ViewChangeListener.ViewChangeEvent event);
+    
+    /**
+     * Invoked after the view is changed. If a {@code beforeViewChange} method blocked
+     * the view change, this method is not called. Be careful of unbounded
+     * recursion if you decide to change the view again in this class.
+     *
+     * <p> 
+     * This is a logical place to deregister listeners that are owned
+     * by the view.
+     *
+     * @param event view change event
+     */
+    public void afterViewChange(ViewChangeListener.ViewChangeEvent event);
+
+    
+}

--- a/src/main/java/org/vaadin/viritin/navigator/package-info.java
+++ b/src/main/java/org/vaadin/viritin/navigator/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 Matti Tahvonen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Enhanced versions of {@code View} and {@code Navigator}.
+ */
+package org.vaadin.viritin.navigator;


### PR DESCRIPTION
MView is an enhanced implementation of View that allows to not only know when a view is entered **into** but also when the view is being **exited**.

The enhancement allow views to have all their relevant code in the view itself, e.g. for deregistering listeners or for validating if the user should be allowed to move away from a view. Currently - with the standard `View` class - such stuff must be put in a ViewChangeListener owned by the `Navigator` and this is just unnecessary and ugly.

MView must be used with MNavigator.  Both are drop-in replacements for their standard counterparts in core Vaadin.

I haven't added the traditional with* methods (for method chaining) on MNavigator but that is surely possible if one wants to be true to the Viritin style. Don't see the great need myself. :-)