### PR TITLE
Close OutputStream to prevent "Write end dead"

### DIFF
--- a/src/main/java/org/vaadin/viritin/button/DownloadButton.java
+++ b/src/main/java/org/vaadin/viritin/button/DownloadButton.java
@@ -78,7 +78,12 @@ public class DownloadButton extends MButton {
         new Thread() {
             @Override
             public void run() {
-                getWriter().write(out);
+                try {
+                    getWriter().write(out);
+                    out.close();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         }.start();
     }


### PR DESCRIPTION
Closing the PipedOutputStream in the writeResponce method should prevent the dreaded "Write end dead" IOException from occurring.