### PR TITLE
TypedSelect allow to configure select implementations

### DIFF
--- a/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
@@ -482,7 +482,7 @@ public class TypedSelect<T> extends CustomField {
         return setOptions(options);
     }
 
-    public Collection<T> getBean() {
+    public Collection<T> getBeans() {
         return (Collection) bic.getItemIds();
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
@@ -7,6 +7,10 @@ import com.vaadin.data.Validator.InvalidValueException;
 import com.vaadin.server.Resource;
 import com.vaadin.ui.*;
 import org.vaadin.viritin.ListContainer;
+import org.vaadin.viritin.fields.config.ComboBoxConfig;
+import org.vaadin.viritin.fields.config.ListSelectConfig;
+import org.vaadin.viritin.fields.config.OptionGroupConfig;
+import org.vaadin.viritin.fields.config.TwinColSelectConfig;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -120,91 +124,148 @@ public class TypedSelect<T> extends CustomField {
         return this;
     }
 
+    public TypedSelect<T> asListSelectType() {
+        return asListSelectType(null);
+    }
+
+    public TypedSelect<T> asListSelectType(ListSelectConfig config) {
+        ListSelect listSelect = new ListSelect() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public String getItemCaption(Object itemId) {
+                return TypedSelect.this.getCaption((T) itemId);
+            }
+
+            @Override
+            public Resource getItemIcon(Object itemId) {
+                if (iconGenerator != null) {
+                    return iconGenerator.getIcon((T) itemId);
+                }
+                return super.getItemIcon(itemId);
+            }
+
+        };
+        if (config != null) {
+            config.configurateListSelect(listSelect);
+        }
+        setSelectInstance(listSelect);
+        return this;
+    }
+
+    public TypedSelect<T> asOptionGroupType() {
+        return asOptionGroupType(null);
+    }
+
+    public TypedSelect<T> asOptionGroupType(OptionGroupConfig config) {
+        OptionGroup optionGroup = new OptionGroup() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public String getItemCaption(Object itemId) {
+                return TypedSelect.this.getCaption((T) itemId);
+            }
+
+            @Override
+            public Resource getItemIcon(Object itemId) {
+                if (iconGenerator != null) {
+                    return iconGenerator.getIcon((T) itemId);
+                }
+                return super.getItemIcon(itemId);
+            }
+
+        };
+        if (config != null) {
+            config.configurateOptionGroup(optionGroup);
+        }
+        setSelectInstance(optionGroup);
+        return this;
+    }
+
+    public TypedSelect<T> asComboBoxType() {
+        return asComboBoxType(null);
+    }
+
+    public TypedSelect<T> asComboBoxType(ComboBoxConfig config) {
+        ComboBox comboBox = new ComboBox() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public String getItemCaption(Object itemId) {
+                return TypedSelect.this.getCaption((T) itemId);
+            }
+
+            @Override
+            public Resource getItemIcon(Object itemId) {
+                if (iconGenerator != null) {
+                    return iconGenerator.getIcon((T) itemId);
+                }
+                return super.getItemIcon(itemId);
+            }
+        };
+        if (config != null) {
+            config.configurateComboBox(comboBox);
+        }
+        setSelectInstance(comboBox);
+        LazyComboBox.fixComboBoxVaadinIssue16647(comboBox);
+        return this;
+    }
+
+    public TypedSelect<T> asTwinColSelectType() {
+        return asTwinColSelectType(null);
+    }
+
+    public TypedSelect<T> asTwinColSelectType(TwinColSelectConfig config) {
+        TwinColSelect twinColSelect = new TwinColSelect() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public String getItemCaption(Object itemId) {
+                return TypedSelect.this.getCaption((T) itemId);
+            }
+
+            @Override
+            public Resource getItemIcon(Object itemId) {
+                if (iconGenerator != null) {
+                    return iconGenerator.getIcon((T) itemId);
+                }
+                return super.getItemIcon(itemId);
+            }
+        };
+        if (config != null) {
+            config.configurateTwinColSelect(twinColSelect);
+        }
+        setSelectInstance(twinColSelect);
+        return this;
+    }
+
+    public TypedSelect<T> asNativeSelectType() {
+        setSelectInstance(new NativeSelect() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public String getItemCaption(Object itemId) {
+                return TypedSelect.this.getCaption((T) itemId);
+            }
+
+            @Override
+            public Resource getItemIcon(Object itemId) {
+                if (iconGenerator != null) {
+                    return iconGenerator.getIcon((T) itemId);
+                }
+                return super.getItemIcon(itemId);
+            }
+        });
+        return this;
+    }
+
     public TypedSelect<T> withSelectType(
             Class<? extends AbstractSelect> selectType) {
         if (selectType == ListSelect.class) {
-            setSelectInstance(new ListSelect() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public String getItemCaption(Object itemId) {
-                    return TypedSelect.this.getCaption((T) itemId);
-                }
-
-                @Override
-                public Resource getItemIcon(Object itemId) {
-                    if (iconGenerator != null) {
-                        return iconGenerator.getIcon((T) itemId);
-                    }
-                    return super.getItemIcon(itemId);
-                }
-
-            });
+            asListSelectType();
         } else if (selectType == OptionGroup.class) {
-            setSelectInstance(new OptionGroup() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public String getItemCaption(Object itemId) {
-                    return TypedSelect.this.getCaption((T) itemId);
-                }
-
-                @Override
-                public Resource getItemIcon(Object itemId) {
-                    if (iconGenerator != null) {
-                        return iconGenerator.getIcon((T) itemId);
-                    }
-                    return super.getItemIcon(itemId);
-                }
-
-            });
+            asOptionGroupType();
         } else if (selectType == ComboBox.class) {
-            setSelectInstance(new ComboBox() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public String getItemCaption(Object itemId) {
-                    return TypedSelect.this.getCaption((T) itemId);
-                }
-
-                @Override
-                public Resource getItemIcon(Object itemId) {
-                    if (iconGenerator != null) {
-                        return iconGenerator.getIcon((T) itemId);
-                    }
-                    return super.getItemIcon(itemId);
-                }
-            });
-            LazyComboBox.fixComboBoxVaadinIssue16647((ComboBox) getSelect());
+            asComboBoxType();
         } else if (selectType == TwinColSelect.class) {
-            setSelectInstance(new TwinColSelect() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public String getItemCaption(Object itemId) {
-                    return TypedSelect.this.getCaption((T) itemId);
-                }
-
-                @Override
-                public Resource getItemIcon(Object itemId) {
-                    if (iconGenerator != null) {
-                        return iconGenerator.getIcon((T) itemId);
-                    }
-                    return super.getItemIcon(itemId);
-                }
-            });
-        } else /*if (selectType == null || selectType == NativeSelect.class)*/ {
-            setSelectInstance(new NativeSelect() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public String getItemCaption(Object itemId) {
-                    return TypedSelect.this.getCaption((T) itemId);
-                }
-
-                @Override
-                public Resource getItemIcon(Object itemId) {
-                    if (iconGenerator != null) {
-                        return iconGenerator.getIcon((T) itemId);
-                    }
-                    return super.getItemIcon(itemId);
-                }
-            });
+            asTwinColSelectType();
+        } else {
+            asNativeSelectType();
         }
         return this;
     }

--- a/src/main/java/org/vaadin/viritin/fields/config/ComboBoxConfig.java
+++ b/src/main/java/org/vaadin/viritin/fields/config/ComboBoxConfig.java
@@ -1,0 +1,62 @@
+package org.vaadin.viritin.fields.config;
+
+import com.vaadin.shared.ui.combobox.FilteringMode;
+import com.vaadin.ui.ComboBox;
+
+/**
+ * Configures fluently the ComboBox within TypedSelect
+ */
+public class ComboBoxConfig {
+    FilteringMode filteringMode;
+    ComboBox.ItemStyleGenerator itemStyleGenerator;
+    Integer pageLength;
+    Boolean textInputAllowed;
+    Boolean scrollToSelectedItem;
+
+    public static final ComboBoxConfig build() {
+        return new ComboBoxConfig();
+    }
+
+    public ComboBoxConfig withFilteringMode(FilteringMode filteringMode) {
+        this.filteringMode = filteringMode;
+        return this;
+    }
+
+    public ComboBoxConfig withItemStyleGenerator(ComboBox.ItemStyleGenerator itemStyleGenerator) {
+        this.itemStyleGenerator = itemStyleGenerator;
+        return this;
+    }
+
+    public ComboBoxConfig withPageLength(int pageLength) {
+        this.pageLength = pageLength;
+        return this;
+    }
+
+    public ComboBoxConfig withTextInputAllowed(boolean textInputAllowed) {
+        this.textInputAllowed = textInputAllowed;
+        return this;
+    }
+
+    public ComboBoxConfig withScrollToSelectedItem(boolean scrollToSelectedItem) {
+        this.scrollToSelectedItem = scrollToSelectedItem;
+        return this;
+    }
+
+    public void configurateComboBox(ComboBox comboBox) {
+        if (filteringMode != null) {
+            comboBox.setFilteringMode(filteringMode);
+        }
+        if (itemStyleGenerator != null) {
+            comboBox.setItemStyleGenerator(itemStyleGenerator);
+        }
+        if (pageLength != null) {
+            comboBox.setPageLength(pageLength);
+        }
+        if (textInputAllowed != null) {
+            comboBox.setTextInputAllowed(textInputAllowed);
+        }
+        if (scrollToSelectedItem != null) {
+            comboBox.setScrollToSelectedItem(scrollToSelectedItem);
+        }
+    }
+}

--- a/src/main/java/org/vaadin/viritin/fields/config/ListSelectConfig.java
+++ b/src/main/java/org/vaadin/viritin/fields/config/ListSelectConfig.java
@@ -1,0 +1,26 @@
+package org.vaadin.viritin.fields.config;
+
+import com.vaadin.ui.ListSelect;
+
+/**
+ * Configures fluently the ListSelect within TypedSelect
+ */
+public class ListSelectConfig {
+
+    Integer rows;
+
+    public static final ListSelectConfig build() {
+        return new ListSelectConfig();
+    }
+
+    public ListSelectConfig withRows(int rows) {
+        this.rows = rows;
+        return this;
+    }
+
+    public void configurateListSelect(ListSelect listSelect) {
+        if (rows != null) {
+            listSelect.setRows(rows);
+        }
+    }
+}

--- a/src/main/java/org/vaadin/viritin/fields/config/OptionGroupConfig.java
+++ b/src/main/java/org/vaadin/viritin/fields/config/OptionGroupConfig.java
@@ -1,0 +1,49 @@
+package org.vaadin.viritin.fields.config;
+
+import com.vaadin.ui.OptionGroup;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Configures fluently the OptionGroup within TypedSelect
+ */
+public class OptionGroupConfig {
+
+    Boolean htmlContentAllowed;
+    Set<Object> disabledItemIds;
+
+    public static final OptionGroupConfig build() {
+        return new OptionGroupConfig();
+    }
+
+    public OptionGroupConfig withHtmlContentAllowed(boolean htmlContentAllowed) {
+        this.htmlContentAllowed = htmlContentAllowed;
+        return this;
+    }
+
+    public OptionGroupConfig withDisabledItemIds(List<Object> objectList) {
+        if (disabledItemIds == null) {
+            disabledItemIds = new HashSet<Object>();
+        }
+        disabledItemIds.add(objectList);
+        return this;
+    }
+
+    public OptionGroupConfig withDisabledItemIds(Object... objects) {
+        return withDisabledItemIds(Arrays.asList(objects));
+    }
+
+    public void configurateOptionGroup(OptionGroup optionGroup) {
+        if (htmlContentAllowed != null) {
+            optionGroup.setHtmlContentAllowed(htmlContentAllowed);
+        }
+        if (disabledItemIds != null) {
+            for (Object o : disabledItemIds) {
+                optionGroup.setItemEnabled(o, false);
+            }
+        }
+    }
+}

--- a/src/main/java/org/vaadin/viritin/fields/config/TwinColSelectConfig.java
+++ b/src/main/java/org/vaadin/viritin/fields/config/TwinColSelectConfig.java
@@ -1,0 +1,44 @@
+package org.vaadin.viritin.fields.config;
+
+import com.vaadin.ui.TwinColSelect;
+
+/**
+ * Configures fluently the TwinColSelect within TypedSelect
+ */
+public class TwinColSelectConfig {
+
+    private Integer rows;
+    private String leftColumnCaption;
+    private String rightColumnCaption;
+
+    public static final TwinColSelectConfig build() {
+        return new TwinColSelectConfig();
+    }
+
+    public TwinColSelectConfig withRows(int rows) {
+        this.rows = rows;
+        return this;
+    }
+
+    public TwinColSelectConfig withLeftColumnCaption(String leftColumnCaption) {
+        this.leftColumnCaption = leftColumnCaption;
+        return this;
+    }
+
+    public TwinColSelectConfig withRightColumnCaption(String rightColumnCaption) {
+        this.rightColumnCaption = rightColumnCaption;
+        return this;
+    }
+
+    public void configurateTwinColSelect(TwinColSelect twinColSelect) {
+        if (rows != null) {
+            twinColSelect.setRows(rows);
+        }
+        if (leftColumnCaption != null) {
+            twinColSelect.setLeftColumnCaption(leftColumnCaption);
+        }
+        if (rightColumnCaption != null) {
+            twinColSelect.setRightColumnCaption(rightColumnCaption);
+        }
+    }
+}


### PR DESCRIPTION
I've extended the current way to specify the SelectType by adding for each Type a separate Function:
- asListSelectType
  - let your configure **rows**
- asOptionGroupType
  - let your configrue **htmlContentAllowed** and **disabledItemIds**
- asComboBoxType
  - let you configure **filteringMode**, **itemStyleGenerator**, **pageLength**, **textInputAllowed** and **scrollToSelectedItem**
- asTwinColSelectType
  - let your configure **rows**, **leftColumnCaption** and **rightColumnCaption**
- asNativeSelectType
  - no specific config possible

By this way we allow an individual configuration without providing the public access to the AbstractSelect. Furthermore it's a clean an easy fluent syntax