### PR TITLE
Tried to rationalize default constructor of some fields as per my com…

### DIFF
--- a/src/main/java/org/vaadin/viritin/fields/EmailField.java
+++ b/src/main/java/org/vaadin/viritin/fields/EmailField.java
@@ -13,6 +13,7 @@ import org.vaadin.viritin.util.HtmlElementPropertySetter;
 public class EmailField extends MTextField {
 
     public EmailField() {
+        super();
     }
 
     public EmailField(String caption) {

--- a/src/main/java/org/vaadin/viritin/fields/MCheckBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/MCheckBox.java
@@ -8,6 +8,7 @@ import com.vaadin.ui.CheckBox;
 public class MCheckBox extends CheckBox {
 
     public MCheckBox() {
+        super();
     }
 
     public MCheckBox(String caption) {
@@ -63,7 +64,7 @@ public class MCheckBox extends CheckBox {
         return this;
     }
 
-    public MCheckBox withValueChangeListener(Property.ValueChangeListener listener) {
+    public MCheckBox withValueChangeListener(ValueChangeListener listener) {
         addValueChangeListener(listener);
         return this;
     }

--- a/src/main/java/org/vaadin/viritin/fields/MDateField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MDateField.java
@@ -16,6 +16,7 @@ import java.util.Map;
 public class MDateField extends DateField {
 
     public MDateField() {
+        super();
     }
 
     public MDateField(String caption) {
@@ -129,7 +130,7 @@ public class MDateField extends DateField {
         return this;
     }
 
-    public MDateField withValueChangeListener(Property.ValueChangeListener listener) {
+    public MDateField withValueChangeListener(ValueChangeListener listener) {
         addValueChangeListener(listener);
         return this;
     }

--- a/src/main/java/org/vaadin/viritin/fields/MPasswordField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MPasswordField.java
@@ -41,6 +41,7 @@ public class MPasswordField extends PasswordField implements EagerValidateable {
     private Validator.InvalidValueException eagerValidationError;
 
     public MPasswordField() {
+        super();
         configureMaddonStuff();
     }
 
@@ -179,7 +180,7 @@ public class MPasswordField extends PasswordField implements EagerValidateable {
         return this;
     }
 
-    public MPasswordField withValueChangeListener(Property.ValueChangeListener listener) {
+    public MPasswordField withValueChangeListener(ValueChangeListener listener) {
         addValueChangeListener(listener);
         return this;
     }

--- a/src/main/java/org/vaadin/viritin/fields/MTextArea.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTextArea.java
@@ -29,6 +29,7 @@ import org.vaadin.viritin.MSize;
 public class MTextArea extends TextArea {
 
     public MTextArea() {
+        super();
         configureMaddonStuff();
     }
 
@@ -103,7 +104,7 @@ public class MTextArea extends TextArea {
         return this;
     }
 
-    public MTextArea withValueChangeListener(Property.ValueChangeListener listener) {
+    public MTextArea withValueChangeListener(ValueChangeListener listener) {
         addValueChangeListener(listener);
         return this;
     }

--- a/src/main/java/org/vaadin/viritin/fields/MTextField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTextField.java
@@ -47,6 +47,7 @@ public class MTextField extends TextField implements EagerValidateable {
     private Boolean spellcheck;
 
     public MTextField() {
+        super();
         configureMaddonStuff();
     }
 
@@ -197,7 +198,7 @@ public class MTextField extends TextField implements EagerValidateable {
         return this;
     }
 
-    public MTextField withValueChangeListener(Property.ValueChangeListener listener) {
+    public MTextField withValueChangeListener(ValueChangeListener listener) {
         addValueChangeListener(listener);
         return this;
     }


### PR DESCRIPTION
…ment in issue #203

Quick question about implementation. This was implemented as:

    public MCheckBox() {
    }
Shouldn't it be:

    public MCheckBox() {
        super();
    }
Small distinction but if you use the other constructors, they all call super (e.g. super(caption)) and the super constructor generally calls this() which in the case of CheckBox contains:

    public CheckBox() {
        registerRpc(rpc);
        registerRpc(focusBlurRpc);
        setValue(Boolean.FALSE);
    }
So if you use the MCheckBox constructor with the caption, or with the caption and an initial state, that registerRpc stuff gets called and if you use the empty constructor it does not. For consistency sake it should probably all follow a common path.

The same is probably true for MDateField, MTextField, MTextArea, EmailField although in those cases it makes less difference.