### PR TITLE
Allow new items with db-generated ids in ElementCollectionField

### DIFF
--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -284,7 +285,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
         }
     }
 
-    private final Map<ET, EditorStuff> pojoToEditor = new HashMap<ET, EditorStuff>();
+    private final Map<ET, EditorStuff> pojoToEditor = new IdentityHashMap<ET, EditorStuff>();
 
     protected final MBeanFieldGroup<ET> getFieldGroupFor(ET pojo) {
         EditorStuff es = pojoToEditor.get(pojo);

--- a/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
+++ b/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
@@ -117,7 +117,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
 
     @Override
     public void removeInternalElement(ET v) {
-        int index = items.indexOf(v);
+        int index = itemsIdentityIndexOf(v);
         items.remove(index);
         int row = index + 1;
         layout.removeRow(row);
@@ -130,7 +130,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
 
     @Override
     public void setPersisted(ET v, boolean persisted) {
-        int row = items.indexOf(v) + 1;
+        int row = itemsIdentityIndexOf(v) + 1;
         if (isAllowRemovingItems()) {
             Button c = (Button) layout.getComponent(getVisibleProperties().
                     size(),
@@ -152,6 +152,15 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
             }
             c.setEnabled(persisted);
         }
+    }
+
+    private int itemsIdentityIndexOf(Object o) {
+        for (int index = 0; index < items.size(); index++) {
+            if (items.get(index) == o) {
+                return index;
+            }
+        }
+        return -1;
     }
 
     private void ensureInited() {


### PR DESCRIPTION
Use items identity, because new items with db-generated ids may be equals.