### PR TITLE
constructor with properties list implemented

### DIFF
--- a/src/main/java/org/vaadin/viritin/ListContainer.java
+++ b/src/main/java/org/vaadin/viritin/ListContainer.java
@@ -76,6 +76,11 @@ public class ListContainer<T> extends AbstractContainer implements
         dynaClass = WrapDynaClass.createDynaClass(type);
     }
 
+    public ListContainer(Class<T> type, String... properties) {
+        this(type);
+        setContainerPropertyIds(properties);
+    }
+
     protected List<T> getBackingList() {
         return backingList;
     }


### PR DESCRIPTION
There is a useful constructor that helps to shorten the code of creating the list container.
For example:
ListContainer container = new ListContainer(MyBean.class, columns);
instead of 
ListContainer container = new ListContainer(MyBean.class);
container.setContainerPropertyIds(columns);

