### PR TITLE
AbstractNumberField width fix

### DIFF
--- a/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
@@ -140,4 +140,22 @@ public abstract class AbstractNumberField<T> extends CustomField<T> implements
         tf.setReadOnly(readOnly);
     }
 
+    @Override
+    public void setWidth(String width) {
+    	super.setWidth(width);
+    	tf.setWidth("100%");
+    }
+    
+    @Override
+    public void setWidth(float width, Unit unit) {
+    	super.setWidth(width, unit);
+    	tf.setWidth("100%");
+    }
+    
+    @Override
+    public void setWidthUndefined() {
+    	super.setWidthUndefined();
+    	tf.setWidthUndefined();
+    }
+    
 }


### PR DESCRIPTION
Fixes a bug where AbstractNumberField did not set the correct size for the internal MTextField when changing the width.