### PR TITLE
Improve code quality by following common conventions

### DIFF
--- a/src/main/java/org/vaadin/viritin/BeanBinder.java
+++ b/src/main/java/org/vaadin/viritin/BeanBinder.java
@@ -22,7 +22,7 @@ package org.vaadin.viritin;
 public class BeanBinder {
 
     public static <T> MBeanFieldGroup<T> bind(T bean, Object objectWithMemberFields, String... nestedProperties) {
-        MBeanFieldGroup<T> beanFieldGroup = new MBeanFieldGroup<T>((Class<T>) bean.getClass());
+        MBeanFieldGroup<T> beanFieldGroup = new MBeanFieldGroup<>((Class<T>) bean.getClass());
         beanFieldGroup.setItemDataSource(bean);
         if(nestedProperties != null) {
             for (String nestedPropertyId : nestedProperties) {

--- a/src/main/java/org/vaadin/viritin/DynaBeanItem.java
+++ b/src/main/java/org/vaadin/viritin/DynaBeanItem.java
@@ -30,7 +30,7 @@ public class DynaBeanItem<T> implements Item {
     /* Container-Item-Property specifications don't say item should always return
      the same property instance, but some components depend on this :-(
      */
-    private Map<Object, DynaProperty> propertyIdToProperty = new HashMap<Object, DynaProperty>();
+    private Map<Object, DynaProperty> propertyIdToProperty = new HashMap<>();
 
     private class DynaProperty implements Property {
 

--- a/src/main/java/org/vaadin/viritin/DynaBeanItem.java
+++ b/src/main/java/org/vaadin/viritin/DynaBeanItem.java
@@ -2,16 +2,17 @@ package org.vaadin.viritin;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.Property;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.commons.beanutils.DynaBean;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.beanutils.WrapDynaBean;
 import org.apache.commons.beanutils.expression.DefaultResolver;
 import org.apache.commons.lang3.ClassUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A standalone version of the DynaBeanItem originally introduced in

--- a/src/main/java/org/vaadin/viritin/DynaBeanItem.java
+++ b/src/main/java/org/vaadin/viritin/DynaBeanItem.java
@@ -37,7 +37,7 @@ public class DynaBeanItem<T> implements Item {
 
         private final String propertyName;
 
-        public DynaProperty(String property) {
+        DynaProperty(String property) {
             propertyName = property;
         }
 

--- a/src/main/java/org/vaadin/viritin/DynaBeanItem.java
+++ b/src/main/java/org/vaadin/viritin/DynaBeanItem.java
@@ -31,7 +31,7 @@ public class DynaBeanItem<T> implements Item {
     /* Container-Item-Property specifications don't say item should always return
      the same property instance, but some components depend on this :-(
      */
-    private Map<Object, DynaProperty> propertyIdToProperty = new HashMap<>();
+    private final Map<Object, DynaProperty> propertyIdToProperty = new HashMap<>();
 
     private class DynaProperty implements Property {
 
@@ -100,7 +100,7 @@ public class DynaBeanItem<T> implements Item {
 
     }
 
-    private T bean;
+    private final T bean;
 
     private transient DynaBean db;
 

--- a/src/main/java/org/vaadin/viritin/DynaBeanItem.java
+++ b/src/main/java/org/vaadin/viritin/DynaBeanItem.java
@@ -2,6 +2,7 @@ package org.vaadin.viritin;
 
 import com.vaadin.data.Item;
 import com.vaadin.data.Property;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,7 +48,7 @@ public class DynaBeanItem<T> implements Item {
             } catch (Exception e) {
                 try {
                     return PropertyUtils.getProperty(bean, propertyName);
-                } catch (Exception ex) {
+                } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
                     throw new RuntimeException(ex);
                 }
             }
@@ -80,7 +81,7 @@ public class DynaBeanItem<T> implements Item {
                     return org.vaadin.viritin.ListContainer.
                             getNestedPropertyType(getDynaBean().getDynaClass(),
                                     propertyName);
-                } catch (Exception ex) {
+                } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException ex) {
                     throw new RuntimeException(ex);
                 }
             }

--- a/src/main/java/org/vaadin/viritin/FilterableListContainer.java
+++ b/src/main/java/org/vaadin/viritin/FilterableListContainer.java
@@ -23,15 +23,15 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
 
     private static final long serialVersionUID = 6410519255465731727L;
 
-    private Set<Filter> filters = new HashSet<Filter>();
+    private final Set<Filter> filters = new HashSet<>();
 
-    private List<T> filteredItems = new ArrayList<T>();
+    private List<T> filteredItems = new ArrayList<>();
 
-    public FilterableListContainer(Class<T> type) {
+    public FilterableListContainer(Class<? extends T> type) {
         super(type);
     }
 
-    public FilterableListContainer(Collection<T> backingList) {
+    public FilterableListContainer(Collection<? extends T> backingList) {
         super(backingList);
     }
 
@@ -64,7 +64,7 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
     }
 
     private void applyFilters() {
-        filteredItems = new ArrayList<T>();
+        filteredItems = new ArrayList<>();
         if (isFiltered()) {
             for (T itemId : super.getBackingList()) {
                 if (passesFilters(itemId)) {

--- a/src/main/java/org/vaadin/viritin/FilterableListContainer.java
+++ b/src/main/java/org/vaadin/viritin/FilterableListContainer.java
@@ -1,15 +1,15 @@
 package org.vaadin.viritin;
 
+import com.vaadin.data.Container;
+import com.vaadin.data.Container.Filterable;
+import com.vaadin.data.Item;
+import com.vaadin.data.util.filter.UnsupportedFilterException;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import com.vaadin.data.Container;
-import com.vaadin.data.Container.Filterable;
-import com.vaadin.data.Item;
-import com.vaadin.data.util.filter.UnsupportedFilterException;
 
 /**
  * A filterable ({@link Container.Filterable}) version of {@link ListContainer}.

--- a/src/main/java/org/vaadin/viritin/LazyList.java
+++ b/src/main/java/org/vaadin/viritin/LazyList.java
@@ -1,7 +1,12 @@
 package org.vaadin.viritin;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * A general purpose helper class to us MTable/ListContainer for service layers
@@ -14,6 +19,8 @@ import java.util.*;
  * @param <T> The type of the objects in the list
  */
 public class LazyList<T> extends AbstractList<T> implements Serializable {
+
+    private static final long serialVersionUID = 2423832460602269469L;
 
     private List<T> findPageFromCache(int pageIndexForReqest) {
         int p = pageIndexForReqest - pageIndex;

--- a/src/main/java/org/vaadin/viritin/LazyList.java
+++ b/src/main/java/org/vaadin/viritin/LazyList.java
@@ -228,7 +228,7 @@ public class LazyList<T> extends AbstractList<T> implements Serializable {
 
     private Map<T, Integer> getIndexCache() {
         if (indexCache == null) {
-            indexCache = new WeakHashMap<T, Integer>();
+            indexCache = new WeakHashMap<>();
         }
         return indexCache;
     }
@@ -284,7 +284,7 @@ public class LazyList<T> extends AbstractList<T> implements Serializable {
             // Increase the amount of cached pages if necessary
             maxPages = sizeOfSublist/pageSize + 1;
         }
-        return new ArrayList<T>(super.subList(fromIndex, toIndex));
+        return new ArrayList<>(super.subList(fromIndex, toIndex));
     }
 
     @Override

--- a/src/main/java/org/vaadin/viritin/ListContainer.java
+++ b/src/main/java/org/vaadin/viritin/ListContainer.java
@@ -343,7 +343,7 @@ public class ListContainer<T> extends AbstractContainer implements
 
     @Override
     public boolean containsId(Object itemId) {
-        return getBackingList().contains((T) itemId);
+        return getBackingList().contains(itemId);
     }
 
     @Override
@@ -360,7 +360,7 @@ public class ListContainer<T> extends AbstractContainer implements
 
     @Override
     public boolean removeItem(Object itemId) throws UnsupportedOperationException {
-        final boolean remove = backingList.remove((T) itemId);
+        final boolean remove = backingList.remove(itemId);
         if (remove) {
             fireItemSetChange();
         }

--- a/src/main/java/org/vaadin/viritin/ListContainer.java
+++ b/src/main/java/org/vaadin/viritin/ListContainer.java
@@ -526,7 +526,7 @@ public class ListContainer<T> extends AbstractContainer implements
 
             private final String propertyName;
 
-            public DynaProperty(String property) {
+            DynaProperty(String property) {
                 propertyName = property;
             }
 

--- a/src/main/java/org/vaadin/viritin/ListContainer.java
+++ b/src/main/java/org/vaadin/viritin/ListContainer.java
@@ -20,21 +20,28 @@ import com.vaadin.data.Container.ItemSetChangeNotifier;
 import com.vaadin.data.Item;
 import com.vaadin.data.Property;
 import com.vaadin.data.util.AbstractContainer;
+import org.apache.commons.beanutils.*;
+import org.apache.commons.beanutils.expression.DefaultResolver;
+import org.apache.commons.beanutils.expression.Resolver;
+import org.apache.commons.collections.comparators.NullComparator;
+import org.apache.commons.collections.comparators.ReverseComparator;
+import org.apache.commons.lang3.ClassUtils;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import org.apache.commons.beanutils.*;
-import org.apache.commons.collections.comparators.NullComparator;
-import org.apache.commons.collections.comparators.ReverseComparator;
-import org.apache.commons.lang3.ClassUtils;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.beanutils.expression.DefaultResolver;
-import org.apache.commons.beanutils.expression.Resolver;
 
 /**
  * A replacement for BeanItemContainer from the core
@@ -47,6 +54,8 @@ import org.apache.commons.beanutils.expression.Resolver;
  */
 public class ListContainer<T> extends AbstractContainer implements
         Container.Indexed, Container.Sortable, ItemSetChangeNotifier {
+
+    private static final long serialVersionUID = -6709228455051205922L;
 
     private List<T> backingList;
     private List<String> properties;

--- a/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
+++ b/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
@@ -93,14 +93,17 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
                             .getMessageInterpolator().interpolate(
                                 notNullAnnotation.message(),
                                 new MessageInterpolator.Context() {
+                                    @Override
                                     public ConstraintDescriptor<?> getConstraintDescriptor() {
                                         return null;
                                     }
 
+                                    @Override
                                     public Object getValidatedValue() {
                                         return null;
                                     }
 
+                                    @Override
                                     public <T> T unwrap(Class<T> type) {
                                         return null;
                                     }

--- a/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
+++ b/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
@@ -576,6 +576,8 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
 
     public MBeanFieldGroup<T> withEagerValidation() {
         return withEagerValidation(new FieldGroupListener() {
+            private static final long serialVersionUID = 2706724523369882782L;
+
             @Override
             public void onFieldGroupChange(MBeanFieldGroup beanFieldGroup) {
             }

--- a/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
+++ b/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
@@ -142,7 +142,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
         }
     }
 
-    private final Set<String> fieldsWithInitiallyDisabledValidation = new HashSet<String>();
+    private final Set<String> fieldsWithInitiallyDisabledValidation = new HashSet<>();
 
     public Set<String> getFieldsWithInitiallyDisabledValidation() {
         return Collections.
@@ -198,7 +198,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
      * @return error messages from "bean level validation"
      */
     public Collection<String> getBeanLevelValidationErrors() {
-        Collection<String> errors = new ArrayList<String>();
+        Collection<String> errors = new ArrayList<>();
         if (getConstraintViolations() != null) {
             for (final ConstraintViolation<T> constraintViolation : getConstraintViolations()) {
                 final MessageInterpolator.Context context = new MessageInterpolator.Context() {
@@ -359,7 +359,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
         }
     }
 
-    private LinkedHashMap<MValidator<T>, Collection<AbstractComponent>> mValidators = new LinkedHashMap<MValidator<T>, Collection<AbstractComponent>>();
+    private LinkedHashMap<MValidator<T>, Collection<AbstractComponent>> mValidators = new LinkedHashMap<>();
 
     /**
      * EXPERIMENTAL: The cross field validation support is still experimental
@@ -392,9 +392,9 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
         return this;
     }
 
-    private final Map<ErrorMessage, AbstractComponent> mValidationErrors = new HashMap<ErrorMessage, AbstractComponent>();
+    private final Map<ErrorMessage, AbstractComponent> mValidationErrors = new HashMap<>();
 
-    private final Map<Class, AbstractComponent> validatorToErrorTarget = new HashMap<Class, AbstractComponent>();
+    private final Map<Class, AbstractComponent> validatorToErrorTarget = new HashMap<>();
 
     /**
      * Sets the "validation error target", the component on which validation
@@ -475,7 +475,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
                         // no specific "target component" for validation error
                         // leave as bean level error
                         if (beanLevelViolations == null) {
-                            beanLevelViolations = new HashSet<Validator.InvalidValueException>();
+                            beanLevelViolations = new HashSet<>();
                         }
                         beanLevelViolations.add(e);
                         mValidationErrors.put(em, null);
@@ -523,7 +523,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
                             // no specific "target component" for validation error
                             // leave as bean level error
                             if (beanLevelViolations == null) {
-                                beanLevelViolations = new HashSet<Validator.InvalidValueException>();
+                                beanLevelViolations = new HashSet<>();
                             }
                             beanLevelViolations.add(e);
                             mValidationErrors.put(em, null);
@@ -612,7 +612,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
      */
     public void unbind() {
         // wrap in array list to avoid CME
-        for (Field<?> field : new ArrayList<Field<?>>(getFields())) {
+        for (Field<?> field : new ArrayList<>(getFields())) {
             field.removeValueChangeListener(this);
             if (field instanceof TextChangeNotifier) {
                 final TextChangeNotifier abstractTextField = (TextChangeNotifier) field;

--- a/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
+++ b/src/main/java/org/vaadin/viritin/MBeanFieldGroup.java
@@ -359,7 +359,7 @@ public class MBeanFieldGroup<T> extends BeanFieldGroup<T> implements
         }
     }
 
-    private LinkedHashMap<MValidator<T>, Collection<AbstractComponent>> mValidators = new LinkedHashMap<>();
+    private final LinkedHashMap<MValidator<T>, Collection<AbstractComponent>> mValidators = new LinkedHashMap<>();
 
     /**
      * EXPERIMENTAL: The cross field validation support is still experimental

--- a/src/main/java/org/vaadin/viritin/SortableLazyList.java
+++ b/src/main/java/org/vaadin/viritin/SortableLazyList.java
@@ -1,8 +1,7 @@
 package org.vaadin.viritin;
 
 import java.io.Serializable;
-import java.util.*;
-import org.vaadin.viritin.LazyList.CountProvider;
+import java.util.List;
 
 /**
  * A general purpose helper class to us MTable/ListContainer for service layers
@@ -15,6 +14,8 @@ import org.vaadin.viritin.LazyList.CountProvider;
  * @param <T> The type of the objects in the list
  */
 public class SortableLazyList<T> extends LazyList<T> implements Serializable {
+
+    private static final long serialVersionUID = 6271514642253054989L;
 
     public void sort(boolean ascending, String property) {
         sortAscending = ascending;

--- a/src/main/java/org/vaadin/viritin/button/ConfirmButton.java
+++ b/src/main/java/org/vaadin/viritin/button/ConfirmButton.java
@@ -18,7 +18,6 @@ package org.vaadin.viritin.button;
 import com.vaadin.server.Resource;
 import com.vaadin.shared.MouseEventDetails;
 import org.vaadin.dialogs.ConfirmDialog;
-import org.vaadin.viritin.button.MButton.MClickListener;
 
 /**
  *

--- a/src/main/java/org/vaadin/viritin/button/DownloadButton.java
+++ b/src/main/java/org/vaadin/viritin/button/DownloadButton.java
@@ -3,6 +3,7 @@ package org.vaadin.viritin.button;
 import com.vaadin.server.FileDownloader;
 import com.vaadin.server.Resource;
 import com.vaadin.server.StreamResource;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/src/main/java/org/vaadin/viritin/button/MButton.java
+++ b/src/main/java/org/vaadin/viritin/button/MButton.java
@@ -15,18 +15,20 @@
  */
 package org.vaadin.viritin.button;
 
-import java.util.LinkedHashSet;
-
 import com.vaadin.server.Resource;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.ui.Button;
 import org.vaadin.viritin.MSize;
+
+import java.util.LinkedHashSet;
 
 /**
  * An extension to basic Vaadin button that adds some handy constructors and
  * fluent API.
  */
 public class MButton extends Button {
+
+    private static final long serialVersionUID = 3859208260278798872L;
 
     public MButton() {
     }

--- a/src/main/java/org/vaadin/viritin/button/MButton.java
+++ b/src/main/java/org/vaadin/viritin/button/MButton.java
@@ -157,7 +157,7 @@ public class MButton extends Button {
 
     public MButton addClickListener(MClickListener listener) {
         if (mClickListeners == null) {
-            mClickListeners = new LinkedHashSet<MClickListener>();
+            mClickListeners = new LinkedHashSet<>();
         }
         mClickListeners.add(listener);
         return this;

--- a/src/main/java/org/vaadin/viritin/components/LocaleSelect.java
+++ b/src/main/java/org/vaadin/viritin/components/LocaleSelect.java
@@ -1,8 +1,9 @@
 package org.vaadin.viritin.components;
 
-import java.util.*;
+import org.vaadin.viritin.fields.CaptionGenerator;
+import org.vaadin.viritin.fields.TypedSelect;
 
-import org.vaadin.viritin.fields.*;
+import java.util.Locale;
 
 /**
  * A select component for {@link java.util.Locale}.

--- a/src/main/java/org/vaadin/viritin/fields/AbstractCaptionGenerator.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractCaptionGenerator.java
@@ -10,6 +10,9 @@ package org.vaadin.viritin.fields;
  */
 public abstract class AbstractCaptionGenerator<T> implements
         CaptionGenerator<T> {
+
+    private static final long serialVersionUID = 7397954730260358087L;
+    
     @Override
     public String getCaption(T option) {
         if (option == null) {

--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -308,7 +308,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
         }
     }
 
-    private final Map<ET, EditorStuff> pojoToEditor = new IdentityHashMap<ET, EditorStuff>();
+    private final Map<ET, EditorStuff> pojoToEditor = new IdentityHashMap<>();
 
     protected final MBeanFieldGroup<ET> getFieldGroupFor(ET pojo) {
         EditorStuff es = pojoToEditor.get(pojo);
@@ -366,14 +366,14 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
         getAndEnsureValue().add(instance);
         addInternalElement(instance);
         fireValueChange(false);
-        fireEvent(new ElementAddedEvent<ET>(this, instance));
+        fireEvent(new ElementAddedEvent<>(this, instance));
     }
 
     public void removeElement(ET elemnentToBeRemoved) {
         removeInternalElement(elemnentToBeRemoved);
         getAndEnsureValue().remove(elemnentToBeRemoved);
         fireValueChange(false);
-        fireEvent(new ElementRemovedEvent<ET>(this, elemnentToBeRemoved));
+        fireEvent(new ElementRemovedEvent<>(this, elemnentToBeRemoved));
     }
 
     public AbstractElementCollection<ET> setVisibleProperties(
@@ -385,7 +385,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
     public List<String> getVisibleProperties() {
         if (visibleProperties == null) {
 
-            visibleProperties = new ArrayList<String>();
+            visibleProperties = new ArrayList<>();
 
             for (java.lang.reflect.Field f : editorType.getDeclaredFields()) {
                 // field order can be counted since jdk6 
@@ -408,7 +408,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
         return this;
     }
 
-    private final Map<String, String> propertyToHeader = new HashMap<String, String>();
+    private final Map<String, String> propertyToHeader = new HashMap<>();
 
     public AbstractElementCollection<ET> setPropertyHeader(String propertyName,
             String propertyHeader) {

--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -340,16 +340,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
                 java.lang.reflect.Field f = editorType.getDeclaredField(property);
                 f.setAccessible(true);
                 c = (Component) f.get(editorsstuff.editor);
-            } catch (NoSuchFieldException ex) {
-                Logger.getLogger(AbstractElementCollection.class.getName()).
-                        log(Level.SEVERE, null, ex);
-            } catch (SecurityException ex) {
-                Logger.getLogger(AbstractElementCollection.class.getName()).
-                        log(Level.SEVERE, null, ex);
-            } catch (IllegalArgumentException ex) {
-                Logger.getLogger(AbstractElementCollection.class.getName()).
-                        log(Level.SEVERE, null, ex);
-            } catch (IllegalAccessException ex) {
+            } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
                 Logger.getLogger(AbstractElementCollection.class.getName()).
                         log(Level.SEVERE, null, ex);
             }

--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -205,7 +205,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
             } else {
                 try {
                     value = (Collection) fieldType.newInstance();
-                } catch (Exception ex) {
+                } catch (IllegalAccessException | InstantiationException ex) {
                     throw new RuntimeException(
                             "Could not instantiate the used colleciton type", ex);
                 }
@@ -258,7 +258,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
         } else {
             try {
                 return elementType.newInstance();
-            } catch (Exception ex) {
+            } catch (IllegalAccessException | InstantiationException ex) {
                 throw new RuntimeException(ex);
             }
         }
@@ -273,7 +273,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
             } else {
                 try {
                     return editorType.newInstance();
-                } catch (Exception ex) {
+                } catch (IllegalAccessException | InstantiationException ex) {
                     throw new RuntimeException(ex);
                 }
             }

--- a/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractElementCollection.java
@@ -8,6 +8,10 @@ import com.vaadin.ui.Field;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Layout;
 import com.vaadin.util.ReflectTools;
+import org.vaadin.viritin.BeanBinder;
+import org.vaadin.viritin.MBeanFieldGroup;
+import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
+
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -20,9 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.vaadin.viritin.BeanBinder;
-import org.vaadin.viritin.MBeanFieldGroup;
-import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
 
 /**
  * A superclass for fields suitable for editing collection of referenced objects tied to parent
@@ -42,7 +43,11 @@ import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
  */
 public abstract class AbstractElementCollection<ET> extends CustomField<Collection> {
 
+    private static final long serialVersionUID = 7785110162928180695L;
+
     public static class ElementAddedEvent<ET> extends Component.Event {
+
+        private static final long serialVersionUID = 2263765199849601501L;
 
         private final ET element;
 
@@ -58,6 +63,8 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
     }
 
     public static class ElementRemovedEvent<ET> extends Component.Event {
+
+        private static final long serialVersionUID = 574545902966053269L;
 
         private final ET element;
 
@@ -126,6 +133,8 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
     protected ET newInstance;
 
     private final FieldGroupListener fieldGroupListener = new FieldGroupListener() {
+
+        private static final long serialVersionUID = 2498166986711639744L;
 
         @Override
         public void onFieldGroupChange(MBeanFieldGroup beanFieldGroup) {
@@ -299,6 +308,7 @@ public abstract class AbstractElementCollection<ET> extends CustomField<Collecti
     }
   
     private class EditorStuff implements Serializable {
+        private static final long serialVersionUID = 5132645136059482705L;
         MBeanFieldGroup<ET> bfg;
         Object editor;
 

--- a/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
+++ b/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
@@ -9,6 +9,7 @@ import org.vaadin.viritin.util.HtmlElementPropertySetter;
 /**
  *
  * @author Matti Tahvonen
+ * @param <T>  field value type
  */
 public abstract class AbstractNumberField<T> extends CustomField<T> implements
         EagerValidateable, FieldEvents.TextChangeNotifier {

--- a/src/main/java/org/vaadin/viritin/fields/CheckBoxGroup.java
+++ b/src/main/java/org/vaadin/viritin/fields/CheckBoxGroup.java
@@ -1,5 +1,11 @@
 package org.vaadin.viritin.fields;
 
+import com.vaadin.data.util.converter.Converter;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.CustomField;
+import com.vaadin.ui.OptionGroup;
+import org.vaadin.viritin.ListContainer;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -9,13 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
-import org.vaadin.viritin.ListContainer;
-
-import com.vaadin.data.util.converter.Converter;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.CustomField;
-import com.vaadin.ui.OptionGroup;
 
 /**
  * An OptionGroup that can be used as a field to modify

--- a/src/main/java/org/vaadin/viritin/fields/CheckBoxGroup.java
+++ b/src/main/java/org/vaadin/viritin/fields/CheckBoxGroup.java
@@ -110,7 +110,7 @@ public class CheckBoxGroup<ET> extends CustomField<Collection> {
             } else {
                 try {
                     c = (Collection) fieldType.newInstance();
-                } catch (Exception ex) {
+                } catch (IllegalAccessException | InstantiationException ex) {
                     throw new RuntimeException(
                             "Could not instantiate the used colleciton type", ex);
                 }

--- a/src/main/java/org/vaadin/viritin/fields/CollectionSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/CollectionSelect.java
@@ -50,7 +50,7 @@ public class CollectionSelect<T> extends CustomField<Collection<T>> {
 				 */
 
 				Collection<T> collection = getInternalValue();
-				HashSet<T> orphaned = new HashSet<T>(collection);
+				HashSet<T> orphaned = new HashSet<>(collection);
 
 				@SuppressWarnings("unchecked")
 				Collection<T> newValueSet = (Collection<T>) select.getValue();
@@ -83,7 +83,7 @@ public class CollectionSelect<T> extends CustomField<Collection<T>> {
 
 	@SuppressWarnings("deprecation")
 	public void setOptions(Collection<T> options) {
-		select.setContainerDataSource(new BeanItemContainer<T>(options));
+		select.setContainerDataSource(new BeanItemContainer<>(options));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/org/vaadin/viritin/fields/CollectionSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/CollectionSelect.java
@@ -22,6 +22,7 @@ public class CollectionSelect<T> extends CustomField<Collection<T>> {
 	private ListSelect select = new ListSelect() {
 
 		@SuppressWarnings("unchecked")
+        @Override
 		public String getItemCaption(Object option) {
 			if (captionGenerator != null) {
 				return captionGenerator.getCaption((T) option);

--- a/src/main/java/org/vaadin/viritin/fields/CollectionSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/CollectionSelect.java
@@ -1,12 +1,12 @@
 package org.vaadin.viritin.fields;
 
-import java.util.Collection;
-import java.util.HashSet;
-
 import com.vaadin.data.util.BeanItemContainer;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomField;
 import com.vaadin.ui.ListSelect;
+
+import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * TODO improve this, just copy pasted from archived SmartFields addon.

--- a/src/main/java/org/vaadin/viritin/fields/CommaSeparatedCollectionField.java
+++ b/src/main/java/org/vaadin/viritin/fields/CommaSeparatedCollectionField.java
@@ -18,6 +18,7 @@ package org.vaadin.viritin.fields;
 import com.vaadin.data.Property;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomField;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.logging.Level;
@@ -67,10 +68,10 @@ public class CommaSeparatedCollectionField extends CustomField<Collection> {
                             } catch (NoSuchMethodException ex) {
                                 try {
                                     collection.add(elementType.getConstructor(String.class).newInstance(part));
-                                } catch (Exception ex1) {
+                                } catch (IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException ex1) {
                                 throw new RuntimeException("The string " + part + " could not be converted to " + elementType.getSimpleName(), ex1);
                                 }
-                            } catch (Exception ex) {
+                            } catch (IllegalAccessException | IllegalArgumentException | SecurityException | InvocationTargetException ex) {
                                 throw new RuntimeException("The string " + part + " could not be converted to " + elementType.getSimpleName(), ex);
                             }
                         } else {

--- a/src/main/java/org/vaadin/viritin/fields/CommaSeparatedCollectionField.java
+++ b/src/main/java/org/vaadin/viritin/fields/CommaSeparatedCollectionField.java
@@ -18,12 +18,11 @@ package org.vaadin.viritin.fields;
 import com.vaadin.data.Property;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomField;
+import org.apache.commons.lang3.StringUtils;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A simple TextField based component to edit collections of objects, which can
@@ -33,6 +32,8 @@ import org.apache.commons.lang3.StringUtils;
  * strategies to convert from String presentation to element types.
  */
 public class CommaSeparatedCollectionField extends CustomField<Collection> {
+
+    private static final long serialVersionUID = 2443075282417590322L;
 
     public interface FromStringInstantiator<T> {
 
@@ -48,6 +49,7 @@ public class CommaSeparatedCollectionField extends CustomField<Collection> {
 
     public CommaSeparatedCollectionField() {
         textField.addValueChangeListener(new ValueChangeListener() {
+            private static final long serialVersionUID = -382717228031608542L;
             @Override
             public void valueChange(Property.ValueChangeEvent event) {
                 if (textField.isUserValueChange()) {

--- a/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
+++ b/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
@@ -73,7 +73,7 @@ import org.vaadin.viritin.layouts.MGridLayout;
  */
 public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
 
-    List<ET> items = new ArrayList<ET>();
+    List<ET> items = new ArrayList<>();
 
     boolean inited = false;
 

--- a/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
+++ b/src/main/java/org/vaadin/viritin/fields/ElementCollectionField.java
@@ -1,13 +1,5 @@
 package org.vaadin.viritin.fields;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.vaadin.viritin.MBeanFieldGroup;
-import org.vaadin.viritin.button.MButton;
-
 import com.vaadin.server.FontAwesome;
 import com.vaadin.ui.AbstractField;
 import com.vaadin.ui.Alignment;
@@ -17,9 +9,16 @@ import com.vaadin.ui.Field;
 import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.themes.ValoTheme;
+import org.vaadin.viritin.MBeanFieldGroup;
 import org.vaadin.viritin.button.ConfirmButton;
+import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.form.AbstractForm;
 import org.vaadin.viritin.layouts.MGridLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A field suitable for editing collection of referenced objects tied to parent
@@ -73,6 +72,8 @@ import org.vaadin.viritin.layouts.MGridLayout;
  */
 public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
 
+    private static final long serialVersionUID = 8573373104105052804L;
+
     List<ET> items = new ArrayList<>();
 
     boolean inited = false;
@@ -112,6 +113,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
             MButton b = new MButton(FontAwesome.EDIT)
                     .withStyleName(ValoTheme.BUTTON_ICON_ONLY)
                     .withListener(new Button.ClickListener() {
+                private static final long serialVersionUID = 5019806363620874205L;
                 @Override
                 public void buttonClick(Button.ClickEvent event) {
                     editInPopup(v);
@@ -137,6 +139,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
         b.withIcon(FontAwesome.TRASH_O)
                 .withStyleName(ValoTheme.BUTTON_ICON_ONLY, ValoTheme.BUTTON_DANGER)
                 .withListener(new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
                     @Override
                     public void buttonClick(Button.ClickEvent event) {
                         removeElement(v);
@@ -413,6 +416,7 @@ public class ElementCollectionField<ET> extends AbstractElementCollection<ET> {
         this.popupEditor = newPopupEditor;
         if (newPopupEditor != null) {
             newPopupEditor.setSavedHandler(new AbstractForm.SavedHandler<ET>() {
+                private static final long serialVersionUID = 389618696563816566L;
                 @Override
                 public void onSave(ET entity) {
                     MBeanFieldGroup<ET> fg = getFieldGroupFor(entity);

--- a/src/main/java/org/vaadin/viritin/fields/ElementCollectionTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/ElementCollectionTable.java
@@ -73,7 +73,7 @@ public class ElementCollectionTable<ET> extends AbstractElementCollection<ET> {
                 }
             });
 
-    private IdentityHashMap<ET, MButton> elementToDelButton = new IdentityHashMap<ET, MButton>();
+    private IdentityHashMap<ET, MButton> elementToDelButton = new IdentityHashMap<>();
 
     boolean inited = false;
 

--- a/src/main/java/org/vaadin/viritin/fields/ElementCollectionTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/ElementCollectionTable.java
@@ -3,14 +3,13 @@ package org.vaadin.viritin.fields;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.ui.*;
 import com.vaadin.ui.themes.ValoTheme;
+import org.vaadin.viritin.MBeanFieldGroup;
+import org.vaadin.viritin.button.MButton;
+import org.vaadin.viritin.layouts.MVerticalLayout;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
-
-import org.vaadin.viritin.MBeanFieldGroup;
-import org.vaadin.viritin.button.MButton;
-import org.vaadin.viritin.layouts.MVerticalLayout;
 
 /**
  * A field suitable for editing collection of referenced objects tied to parent

--- a/src/main/java/org/vaadin/viritin/fields/EnumSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/EnumSelect.java
@@ -4,6 +4,7 @@ package org.vaadin.viritin.fields;
 import com.vaadin.data.Property;
 import com.vaadin.data.Validator;
 import com.vaadin.ui.NativeSelect;
+
 import java.util.Collection;
 
 public class EnumSelect<T> extends TypedSelect<T> {

--- a/src/main/java/org/vaadin/viritin/fields/FilterableTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/FilterableTable.java
@@ -25,10 +25,12 @@ import java.util.List;
 /**
  * Extension of the {@link org.vaadin.viritin.fields.MTable} class which supports filtering based on
  * {@link org.vaadin.viritin.FilterableListContainer}.
+ * 
+ * @param <T> the type of the POJO listed in this Table.
  */
 public class FilterableTable<T> extends MTable<T> {
 
-    private List<Filter> pendingFilters = new ArrayList<Filter>();
+    private final List<Filter> pendingFilters = new ArrayList<>();
 
     public FilterableTable() {
 
@@ -47,13 +49,13 @@ public class FilterableTable<T> extends MTable<T> {
     }
 
     @Override
-    protected FilterableListContainer<T> createContainer(Class<T> type) {
-        return new FilterableListContainer<T>(type);
+    protected FilterableListContainer<T> createContainer(Class<? extends T> type) {
+        return new FilterableListContainer<>(type);
     }
 
     @Override
     protected FilterableListContainer<T> createContainer(Collection<T> beans) {
-        return new FilterableListContainer<T>(beans);
+        return new FilterableListContainer<>(beans);
     }
 
     @Override
@@ -61,6 +63,7 @@ public class FilterableTable<T> extends MTable<T> {
         return (FilterableListContainer<T>) super.getContainer();
     }
 
+    @Override
     protected void ensureBeanItemContainer(Collection<T> beans) {
         super.ensureBeanItemContainer(beans);
 

--- a/src/main/java/org/vaadin/viritin/fields/FilterableTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/FilterableTable.java
@@ -67,8 +67,9 @@ public class FilterableTable<T> extends MTable<T> {
     protected void ensureBeanItemContainer(Collection<T> beans) {
         super.ensureBeanItemContainer(beans);
 
-        for (Filter filter : pendingFilters)
+        for (Filter filter : pendingFilters) {
             getContainer().addContainerFilter(filter);
+        }
         pendingFilters.clear();
     }
 

--- a/src/main/java/org/vaadin/viritin/fields/FilterableTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/FilterableTable.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public class FilterableTable<T> extends MTable<T> {
 
+    private static final long serialVersionUID = -8345842706524882553L;
+
     private final List<Filter> pendingFilters = new ArrayList<>();
 
     public FilterableTable() {

--- a/src/main/java/org/vaadin/viritin/fields/IconGenerator.java
+++ b/src/main/java/org/vaadin/viritin/fields/IconGenerator.java
@@ -1,6 +1,7 @@
 package org.vaadin.viritin.fields;
 
 import com.vaadin.server.Resource;
+
 import java.io.Serializable;
 
 /**

--- a/src/main/java/org/vaadin/viritin/fields/IntegerSliderField.java
+++ b/src/main/java/org/vaadin/viritin/fields/IntegerSliderField.java
@@ -48,16 +48,7 @@ public class IntegerSliderField extends IntegerField {
                 if(min != null) {
                     setMin((int) min.value());
                 }
-            } catch (NoSuchFieldException ex) {
-                Logger.getLogger(IntegerSliderField.class.getName()).
-                        log(Level.SEVERE, null, ex);
-            } catch (SecurityException ex) {
-                Logger.getLogger(IntegerSliderField.class.getName()).
-                        log(Level.SEVERE, null, ex);
-            } catch (IllegalArgumentException ex) {
-                Logger.getLogger(IntegerSliderField.class.getName()).
-                        log(Level.SEVERE, null, ex);
-            } catch (IllegalAccessException ex) {
+            } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
                 Logger.getLogger(IntegerSliderField.class.getName()).
                         log(Level.SEVERE, null, ex);
             }

--- a/src/main/java/org/vaadin/viritin/fields/IntegerSliderField.java
+++ b/src/main/java/org/vaadin/viritin/fields/IntegerSliderField.java
@@ -2,17 +2,20 @@ package org.vaadin.viritin.fields;
 
 import com.vaadin.data.Validator;
 import com.vaadin.data.validator.BeanValidator;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import java.lang.reflect.Field;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 
 /**
  *
  * @author Matti Tahvonen
  */
 public class IntegerSliderField extends IntegerField {
+
+    private static final long serialVersionUID = -3019209950602573361L;
 
     private Integer max;
     private Integer min;
@@ -40,13 +43,13 @@ public class IntegerSliderField extends IntegerField {
                 
                 Field field = beantype.getDeclaredField(fieldName);
                 field.setAccessible(true);
-                Max max = field.getAnnotation(Max.class);
-                if(max != null) {
-                    setMax((int) max.value());
+                Max maxAnnotation = field.getAnnotation(Max.class);
+                if(maxAnnotation != null) {
+                    setMax((int) maxAnnotation.value());
                 }
-                Min min = field.getAnnotation(Min.class);
-                if(min != null) {
-                    setMin((int) min.value());
+                Min minAnnotation = field.getAnnotation(Min.class);
+                if(minAnnotation != null) {
+                    setMin((int) minAnnotation.value());
                 }
             } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
                 Logger.getLogger(IntegerSliderField.class.getName()).

--- a/src/main/java/org/vaadin/viritin/fields/LabelField.java
+++ b/src/main/java/org/vaadin/viritin/fields/LabelField.java
@@ -19,10 +19,14 @@ import org.vaadin.viritin.label.RichText;
  *            the type of the entity
  */
 public class LabelField<T> extends CustomField<T> {
+
+    private static final long serialVersionUID = -3079451926367430515L;
     private final Class<T> type;
 
     private static class ToStringCaptionGenerator<T> implements
             CaptionGenerator<T> {
+
+        private static final long serialVersionUID = 1149675718238329960L;
 
         @Override
         public String getCaption(T option) {

--- a/src/main/java/org/vaadin/viritin/fields/LabelField.java
+++ b/src/main/java/org/vaadin/viritin/fields/LabelField.java
@@ -40,7 +40,7 @@ public class LabelField<T> extends CustomField<T> {
         setCaption(caption);
     }
 
-    private CaptionGenerator<T> captionGenerator = new ToStringCaptionGenerator<T>();
+    private CaptionGenerator<T> captionGenerator = new ToStringCaptionGenerator<>();
     private Label label = new RichText();
 
     public LabelField(Class<T> type) {

--- a/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
@@ -204,7 +204,7 @@ public class LazyComboBox<T> extends TypedSelect<T> {
     private static class DummyFilterableListContainer<T> extends ListContainer<T>
             implements Filterable {
 
-        public DummyFilterableListContainer(Class<T> type,
+        DummyFilterableListContainer(Class<T> type,
                 Collection<T> backingList) {
             super(type, backingList);
         }

--- a/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
@@ -10,10 +10,10 @@ import com.vaadin.ui.ComboBox;
 import org.apache.commons.lang3.ObjectUtils;
 import org.vaadin.viritin.LazyList;
 import org.vaadin.viritin.ListContainer;
+import org.vaadin.viritin.util.HtmlElementPropertySetter;
 
 import java.util.Collection;
 import java.util.List;
-import org.vaadin.viritin.util.HtmlElementPropertySetter;
 
 /**
  * This class tries to provide a simple lazy loading connection form ComboBox to
@@ -90,6 +90,8 @@ public class LazyComboBox<T> extends TypedSelect<T> {
         // piggyback to simple paging provider
         piggybackLazyList = new LazyList<>(new LazyList.PagingProvider() {
 
+            private static final long serialVersionUID = 1027614132444478021L;
+
             @Override
             public List findEntities(int firstRow) {
                 return filterablePageProvider.findEntities(firstRow,
@@ -97,6 +99,8 @@ public class LazyComboBox<T> extends TypedSelect<T> {
             }
         },
                 new LazyList.CountProvider() {
+                    private static final long serialVersionUID = -7339189124024626177L;
+
                     @Override
                     public int size() {
                         return countProvider1.size(getCurrentFilter());
@@ -176,6 +180,8 @@ public class LazyComboBox<T> extends TypedSelect<T> {
      */
     protected LazyComboBox() {
         setCaptionGenerator(new CaptionGenerator<T>() {
+            private static final long serialVersionUID = 9213991656985157568L;
+
             @Override
             public String getCaption(T option) {
                 return option.toString();

--- a/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
@@ -88,7 +88,7 @@ public class LazyComboBox<T> extends TypedSelect<T> {
             final FilterablePagingProvider filterablePageProvider,
             final FilterableCountProvider countProvider1, int pageLength) {
         // piggyback to simple paging provider
-        piggybackLazyList = new LazyList<T>(new LazyList.PagingProvider() {
+        piggybackLazyList = new LazyList<>(new LazyList.PagingProvider() {
 
             @Override
             public List findEntities(int firstRow) {
@@ -146,7 +146,7 @@ public class LazyComboBox<T> extends TypedSelect<T> {
 
         };
 
-        setBic(new DummyFilterableListContainer<T>(elementType,
+        setBic(new DummyFilterableListContainer<>(elementType,
                 piggybackLazyList));
         comboBox.setContainerDataSource(getBic());
         if(Version.getMajorVersion() >= 7  && Version.getMinorVersion() >= 5 ) {

--- a/src/main/java/org/vaadin/viritin/fields/MTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTable.java
@@ -680,7 +680,7 @@ public class MTable<T> extends Table {
                 setSortContainerPropertyId(sortProperty);
 
             }
-        } catch (Exception e) {
+        } catch (UnsupportedOperationException e) {
             throw new RuntimeException(e);
         } finally {
             isSorting = false;

--- a/src/main/java/org/vaadin/viritin/fields/MTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTable.java
@@ -69,8 +69,7 @@ public class MTable<T> extends Table {
     private String sortProperty;
     private boolean sortAscending;
 
-    public MTable() {
-    }
+    public MTable() {}
 
     /**
      * Constructs a Table with explicit bean type. Handy for example if your
@@ -78,13 +77,13 @@ public class MTable<T> extends Table {
      *
      * @param type the type of beans that are listed in this table
      */
-    public MTable(Class<T> type) {
+    public MTable(Class<? extends T> type) {
         bic = createContainer(type);
         setContainerDataSource(bic);
     }
 
     public MTable(T... beans) {
-        this(new ArrayList<T>(Arrays.asList(beans)));
+        this(new ArrayList<>(Arrays.asList(beans)));
     }
 
     /**
@@ -256,12 +255,12 @@ public class MTable<T> extends Table {
         return this;
     }
 
-    protected ListContainer<T> createContainer(Class<T> type) {
-        return new ListContainer<T>(type);
+    protected ListContainer<T> createContainer(Class<? extends T> type) {
+        return new ListContainer<>(type);
     }
 
     protected ListContainer<T> createContainer(Collection<T> beans) {
-        return new ListContainer<T>(beans);
+        return new ListContainer<>(beans);
     }
 
     protected ListContainer<T> getContainer() {

--- a/src/main/java/org/vaadin/viritin/fields/MTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTable.java
@@ -15,21 +15,6 @@
  */
 package org.vaadin.viritin.fields;
 
-import static org.vaadin.viritin.LazyList.DEFAULT_PAGE_SIZE;
-
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
-import org.apache.commons.lang3.StringUtils;
-import org.vaadin.viritin.LazyList;
-import org.vaadin.viritin.ListContainer;
-import org.vaadin.viritin.MSize;
-import org.vaadin.viritin.SortableLazyList;
-
 import com.vaadin.event.ItemClickEvent;
 import com.vaadin.event.ItemClickEvent.ItemClickListener;
 import com.vaadin.event.MouseEvents;
@@ -38,7 +23,21 @@ import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Table;
 import com.vaadin.util.ReflectTools;
+import org.apache.commons.lang3.StringUtils;
+import org.vaadin.viritin.LazyList;
+import org.vaadin.viritin.ListContainer;
+import org.vaadin.viritin.MSize;
+import org.vaadin.viritin.SortableLazyList;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+
+import static org.vaadin.viritin.LazyList.DEFAULT_PAGE_SIZE;
 
 /**
  * A better typed version of the Table component in Vaadin. Expects that users
@@ -57,6 +56,8 @@ import java.util.List;
  * @param <T> the type of the POJO listed in this Table.
  */
 public class MTable<T> extends Table {
+
+    private static final long serialVersionUID = 3330985834015680723L;
 
     private ListContainer<T> bic;
     private String[] pendingProperties;
@@ -537,6 +538,7 @@ public class MTable<T> extends Table {
     private void ensureTypedItemClickPiggybackListener() {
         if (itemClickPiggyback == null) {
             itemClickPiggyback = new ItemClickListener() {
+                private static final long serialVersionUID = -2318797984292753676L;
                 @Override
                 public void itemClick(ItemClickEvent event) {
                     fireEvent(new RowClickEvent<T>(event));
@@ -558,6 +560,7 @@ public class MTable<T> extends Table {
     public MTable<T> withGeneratedColumn(String columnId,
             final SimpleColumnGenerator<T> columnGenerator) {
         addGeneratedColumn(columnId, new ColumnGenerator() {
+            private static final long serialVersionUID = 2855441121974230973L;
             @Override
             public Object generateCell(Table source, Object itemId,
                     Object columnId) {
@@ -568,6 +571,8 @@ public class MTable<T> extends Table {
     }
 
     public static class SortEvent extends Component.Event {
+
+        private static final long serialVersionUID = 267382182533317834L;
 
         private boolean preventContainerSort = false;
         private final boolean sortAscending;
@@ -696,9 +701,10 @@ public class MTable<T> extends Table {
      * @param <T> the type of the row 
      */
     public static class RowClickEvent<T> extends MouseEvents.ClickEvent {
-
+        private static final long serialVersionUID = -73902815731458960L;
+        
         public static final Method TYPED_ITEM_CLICK_METHOD;
-
+        
         static {
             try {
                 TYPED_ITEM_CLICK_METHOD = RowClickListener.class.

--- a/src/main/java/org/vaadin/viritin/fields/MTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MTable.java
@@ -421,7 +421,7 @@ public class MTable<T> extends Table {
     }
 
     public MTable<T> setBeans(T... beans) {
-        setBeans(new ArrayList<T>(Arrays.asList(beans)));
+        setBeans(new ArrayList<>(Arrays.asList(beans)));
         return this;
     }
     

--- a/src/main/java/org/vaadin/viritin/fields/MValueChangeEvent.java
+++ b/src/main/java/org/vaadin/viritin/fields/MValueChangeEvent.java
@@ -21,6 +21,7 @@ import com.vaadin.data.Property;
 /**
  *
  * @author mattitahvonenitmill
+ * @param <T>  the value type
  */
 public interface MValueChangeEvent<T> extends Property.ValueChangeEvent {
     T getValue();

--- a/src/main/java/org/vaadin/viritin/fields/MValueChangeEventImpl.java
+++ b/src/main/java/org/vaadin/viritin/fields/MValueChangeEventImpl.java
@@ -17,6 +17,7 @@ package org.vaadin.viritin.fields;
 
 import com.vaadin.ui.AbstractField;
 import com.vaadin.ui.Field;
+
 import java.lang.reflect.Method;
 
 public class MValueChangeEventImpl<T> extends AbstractField.ValueChangeEvent implements MValueChangeEvent<T> {

--- a/src/main/java/org/vaadin/viritin/fields/MapField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MapField.java
@@ -69,7 +69,7 @@ public class MapField<K, V> extends CustomField<Map> {
     private boolean allowNewItems = true;
     private boolean allowRemovingItems = true;
     private boolean allowEditItems = true;
-    private final Map<K, EntryEditor> pojoToEditor = new HashMap<K, EntryEditor>();
+    private final Map<K, EntryEditor> pojoToEditor = new HashMap<>();
     private EntryEditor newEntryEditor;
 
     public MapField() {
@@ -291,14 +291,14 @@ public class MapField<K, V> extends CustomField<Map> {
         getAndEnsureValue().put(key, value);
         addInternalElement(key, value);
         fireValueChange(false);
-        fireEvent(new ElementAddedEvent<K>(this, key));
+        fireEvent(new ElementAddedEvent<>(this, key));
     }
 
     public void removeElement(K keyToBeRemoved) {
         removeInternalElement(keyToBeRemoved);
         getAndEnsureValue().remove(keyToBeRemoved);
         fireValueChange(false);
-        fireEvent(new ElementRemovedEvent<K>(this, keyToBeRemoved));
+        fireEvent(new ElementRemovedEvent<>(this, keyToBeRemoved));
     }
 
     @Override

--- a/src/main/java/org/vaadin/viritin/fields/MapField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MapField.java
@@ -31,13 +31,13 @@ import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
  */
 public class MapField<K, V> extends CustomField<Map> {
 
-    private static final Method addedMethod;
-    private static final Method removedMethod;
+    private static final Method ADDED_METHOD;
+    private static final Method REMOVED_METHOD;
 
     static {
-        addedMethod = ReflectTools.findMethod(ElementAddedListener.class,
+        ADDED_METHOD = ReflectTools.findMethod(ElementAddedListener.class,
                 "elementAdded", ElementAddedEvent.class);
-        removedMethod = ReflectTools.findMethod(ElementRemovedListener.class,
+        REMOVED_METHOD = ReflectTools.findMethod(ElementRemovedListener.class,
                 "elementRemoved", ElementRemovedEvent.class);
     }
 
@@ -97,25 +97,25 @@ public class MapField<K, V> extends CustomField<Map> {
 
     public MapField<K, V> addElementAddedListener(
             ElementAddedListener<K> listener) {
-        addListener(ElementAddedEvent.class, listener, addedMethod);
+        addListener(ElementAddedEvent.class, listener, ADDED_METHOD);
         return this;
     }
 
     public MapField<K, V> removeElementAddedListener(
             ElementAddedListener listener) {
-        removeListener(ElementAddedEvent.class, listener, addedMethod);
+        removeListener(ElementAddedEvent.class, listener, ADDED_METHOD);
         return this;
     }
 
     public MapField<K, V> addElementRemovedListener(
             ElementRemovedListener<K> listener) {
-        addListener(ElementRemovedEvent.class, listener, removedMethod);
+        addListener(ElementRemovedEvent.class, listener, REMOVED_METHOD);
         return this;
     }
 
     public MapField<K, V> removeElementRemovedListener(
             ElementRemovedListener listener) {
-        removeListener(ElementRemovedEvent.class, listener, removedMethod);
+        removeListener(ElementRemovedEvent.class, listener, REMOVED_METHOD);
         return this;
     }
 
@@ -233,7 +233,7 @@ public class MapField<K, V> extends CustomField<Map> {
 
     }
 
-    private void renameValue(Object oldKey, String key) {
+    private void renameValue(K oldKey, String key) {
         K tKey;
         try {
             tKey = (K) key;
@@ -272,7 +272,7 @@ public class MapField<K, V> extends CustomField<Map> {
 
     }
 
-    protected final EntryEditor getFieldGroupFor(K key) {
+    private EntryEditor getFieldGroupFor(K key) {
         EntryEditor ee = pojoToEditor.get(key);
         if (ee == null) {
             final TextField k = createKeyEditorInstance();
@@ -420,9 +420,9 @@ public class MapField<K, V> extends CustomField<Map> {
         TextField keyEditor;
         TextField valueEditor;
         Button delete;
-        Object oldKey;
+        K oldKey;
 
-        public EntryEditor(TextField ke, TextField valueEditor, Object k) {
+        public EntryEditor(TextField ke, TextField valueEditor, K k) {
             this.keyEditor = ke;
             this.valueEditor = valueEditor;
             delete = new Button(FontAwesome.TRASH);

--- a/src/main/java/org/vaadin/viritin/fields/MapField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MapField.java
@@ -422,7 +422,7 @@ public class MapField<K, V> extends CustomField<Map> {
         Button delete;
         K oldKey;
 
-        public EntryEditor(TextField ke, TextField valueEditor, K k) {
+        EntryEditor(TextField ke, TextField valueEditor, K k) {
             this.keyEditor = ke;
             this.valueEditor = valueEditor;
             delete = new Button(FontAwesome.TRASH);

--- a/src/main/java/org/vaadin/viritin/fields/MapField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MapField.java
@@ -12,6 +12,7 @@ import com.vaadin.ui.Layout;
 import com.vaadin.ui.TextField;
 import com.vaadin.util.ReflectTools;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -172,7 +173,7 @@ public class MapField<K, V> extends CustomField<Map> {
             } else {
                 try {
                     value = (Map) fieldType.newInstance();
-                } catch (Exception ex) {
+                } catch (IllegalAccessException | InstantiationException ex) {
                     throw new RuntimeException(
                             "Could not instantiate the used colleciton type", ex);
                 }
@@ -213,7 +214,7 @@ public class MapField<K, V> extends CustomField<Map> {
         } catch (ClassCastException e) {
             try {
                 tKey = keyType.getConstructor(String.class).newInstance(key);
-            } catch (Exception ex) {
+            } catch (IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
                 throw new RuntimeException("No suitable constructor found", ex);
             }
         }
@@ -223,7 +224,7 @@ public class MapField<K, V> extends CustomField<Map> {
         } catch (ClassCastException e) {
             try {
                 tVal = valueType.getConstructor(String.class).newInstance(value);
-            } catch (Exception ex) {
+            } catch (IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
                 throw new RuntimeException("No suitable constructor found", ex);
             }
         }
@@ -239,7 +240,7 @@ public class MapField<K, V> extends CustomField<Map> {
         } catch (ClassCastException e) {
             try {
                 tKey = keyType.getConstructor(String.class).newInstance(key);
-            } catch (Exception ex) {
+            } catch (IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException ex) {
                 throw new RuntimeException("No suitable constructor found", ex);
             }
         }
@@ -257,7 +258,7 @@ public class MapField<K, V> extends CustomField<Map> {
             } catch (ClassCastException ex) {
                 try {
                     value = valueType.getConstructor(String.class).newInstance(strValue);
-                } catch (Exception ex1) {
+                } catch (IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException ex1) {
                     value = null;
                 }
             }

--- a/src/main/java/org/vaadin/viritin/fields/MapField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MapField.java
@@ -11,14 +11,15 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.Layout;
 import com.vaadin.ui.TextField;
 import com.vaadin.util.ReflectTools;
+import org.vaadin.viritin.MBeanFieldGroup;
+import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
+
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import org.vaadin.viritin.MBeanFieldGroup;
-import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
 
 /**
  * A field to edit simple map structures like string to Integer/Double/Float 
@@ -50,6 +51,8 @@ public class MapField<K, V> extends CustomField<Map> {
     protected K newInstance;
 
     private final FieldGroupListener fieldGroupListener = new FieldGroupListener() {
+
+        private static final long serialVersionUID = 1741634663680831911L;
 
         @Override
         public void onFieldGroupChange(MBeanFieldGroup beanFieldGroup) {
@@ -417,6 +420,7 @@ public class MapField<K, V> extends CustomField<Map> {
 
     private class EntryEditor implements Serializable {
 
+        private static final long serialVersionUID = 5710635901082609223L;
         TextField keyEditor;
         TextField valueEditor;
         Button delete;

--- a/src/main/java/org/vaadin/viritin/fields/MapField.java
+++ b/src/main/java/org/vaadin/viritin/fields/MapField.java
@@ -210,7 +210,7 @@ public class MapField<K, V> extends CustomField<Map> {
         }
         K tKey;
         try {
-            tKey = (K) key;
+            tKey = key;
         } catch (ClassCastException e) {
             try {
                 tKey = keyType.getConstructor(String.class).newInstance(key);
@@ -436,7 +436,7 @@ public class MapField<K, V> extends CustomField<Map> {
                     while(iterator.next() != keyEditor) {
                         idx++;
                     }
-                    mainLayout.removeRow((int) idx/3);
+                    mainLayout.removeRow(idx/3);
                 }
             });
 
@@ -459,7 +459,7 @@ public class MapField<K, V> extends CustomField<Map> {
             valueEditor.addValueChangeListener(new Property.ValueChangeListener() {
                 @Override
                 public void valueChange(Property.ValueChangeEvent event) {
-                    replaceValue((K) EntryEditor.this.oldKey, EntryEditor.this.valueEditor.getValue());
+                    replaceValue(EntryEditor.this.oldKey, EntryEditor.this.valueEditor.getValue());
                 }
 
             });

--- a/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
@@ -192,7 +192,7 @@ public class MultiSelectTable<ET> extends CustomField<Collection> {
             } else {
                 try {
                     c = (Collection) fieldType.newInstance();
-                } catch (Exception ex) {
+                } catch (IllegalAccessException | InstantiationException ex) {
                     throw new RuntimeException(
                             "Could not instantiate the used colleciton type", ex);
                 }

--- a/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
@@ -1,5 +1,15 @@
 package org.vaadin.viritin.fields;
 
+import com.vaadin.data.Property;
+import com.vaadin.data.util.converter.Converter;
+import com.vaadin.server.Resource;
+import com.vaadin.shared.ui.MultiSelectMode;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.CustomField;
+import com.vaadin.ui.Table;
+import org.vaadin.viritin.ListContainer;
+import org.vaadin.viritin.MSize;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -9,17 +19,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
-import org.vaadin.viritin.ListContainer;
-
-import com.vaadin.data.Property;
-import com.vaadin.data.util.converter.Converter;
-import com.vaadin.server.Resource;
-import com.vaadin.shared.ui.MultiSelectMode;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.CustomField;
-import com.vaadin.ui.Table;
-import org.vaadin.viritin.MSize;
 
 /**
  * A Table that can be used as a field to modify List&gt;YourDomainObject&lt; or
@@ -37,10 +36,13 @@ import org.vaadin.viritin.MSize;
  */
 public class MultiSelectTable<ET> extends CustomField<Collection> {
 
+    private static final long serialVersionUID = -3245403481676039947L;
+
     private String[] visProps;
     private String[] pendingHeaders;
 
     Table table = new Table() {
+        private static final long serialVersionUID = -770469825702542170L;
 
         {
             setSelectable(true);
@@ -292,6 +294,7 @@ public class MultiSelectTable<ET> extends CustomField<Collection> {
         setHeight("230px");
         // TODO verify if this is needed in real usage, but at least to pass the test
         setConverter(new Converter<Collection, Collection>() {
+            private static final long serialVersionUID = -20358585168853508L;
 
             @Override
             public Collection convertToModel(Collection value,

--- a/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
+++ b/src/main/java/org/vaadin/viritin/fields/MultiSelectTable.java
@@ -67,12 +67,12 @@ public class MultiSelectTable<ET> extends CustomField<Collection> {
                 // TODO add strategies for maintaining the order in case of List
                 // e.g. same as listing, selection order ...
                 Set newvalue = (Set) getValue();
-                Set<ET> orphaned = new HashSet<ET>(oldvalue);
+                Set<ET> orphaned = new HashSet<>(oldvalue);
                 orphaned.removeAll(newvalue);
                 removeRelation(orphaned);
                 allRemovedRelations.addAll(orphaned);
                 allAddedRelations.removeAll(orphaned);
-                Set<ET> newValues = new LinkedHashSet<ET>(newvalue);
+                Set<ET> newValues = new LinkedHashSet<>(newvalue);
                 newValues.removeAll(oldvalue);
                 addRelation(newValues);
                 allAddedRelations.addAll(newValues);
@@ -84,8 +84,8 @@ public class MultiSelectTable<ET> extends CustomField<Collection> {
     };
     private Class<ET> optionType;
 
-    private Set<ET> allAddedRelations = new HashSet<ET>();
-    private Set<ET> allRemovedRelations = new HashSet<ET>();
+    private Set<ET> allAddedRelations = new HashSet<>();
+    private Set<ET> allRemovedRelations = new HashSet<>();
 
     public MultiSelectTable(Class<ET> optionType) {
         this();
@@ -151,7 +151,7 @@ public class MultiSelectTable<ET> extends CustomField<Collection> {
      * set by e.g. FieldGroup) or explicit call to clearModifiedRelations().
      */
     public Set<ET> getAllModifiedRelations() {
-        HashSet<ET> all = new HashSet<ET>(allAddedRelations);
+        HashSet<ET> all = new HashSet<>(allAddedRelations);
         all.addAll(allRemovedRelations);
         return all;
     }

--- a/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
+++ b/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
@@ -13,6 +13,7 @@ import com.vaadin.ui.themes.Reindeer;
 import java.util.Arrays;
 
 import com.vaadin.ui.themes.ValoTheme;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
 import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.form.AbstractForm;
@@ -202,7 +203,7 @@ public class SubSetSelector<ET> extends CustomField<Collection> implements Abstr
     protected ET instantiateOption(String stringInput) {
         try {
             return elementType.getConstructor().newInstance();
-        } catch (Exception e) {
+        } catch (IllegalAccessException | IllegalArgumentException | InstantiationException | NoSuchMethodException | SecurityException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
+++ b/src/main/java/org/vaadin/viritin/fields/SubSetSelector.java
@@ -1,24 +1,22 @@
 package org.vaadin.viritin.fields;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.vaadin.data.Property;
 import com.vaadin.server.FontAwesome;
 import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.themes.Reindeer;
-
-import java.util.Arrays;
-
 import com.vaadin.ui.themes.ValoTheme;
-import java.lang.reflect.InvocationTargetException;
-import java.util.HashSet;
 import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.form.AbstractForm;
 import org.vaadin.viritin.layouts.MHorizontalLayout;
 import org.vaadin.viritin.layouts.MVerticalLayout;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 
 /**
  * Selects a set of beans from a larger set of choices. Bit similar UI component

--- a/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
@@ -312,7 +312,7 @@ public class TypedSelect<T> extends CustomField<T> {
 
         if (fieldType == null) {
             try {
-                fieldType = (Class<T>) ((Container.Sortable) select
+                fieldType = (Class<T>) ((Container.Ordered) select
                         .getContainerDataSource()).firstItemId().getClass();
             } catch (Exception e) {
                 // If field type isn't set or can't be detected just report

--- a/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
+++ b/src/main/java/org/vaadin/viritin/fields/TypedSelect.java
@@ -57,7 +57,7 @@ public class TypedSelect<T> extends CustomField<T> {
      */
     public TypedSelect(Class<T> type) {
         this.fieldType = type;
-        bic = new ListContainer<T>(type);
+        bic = new ListContainer<>(type);
     }
 
     /**
@@ -435,7 +435,7 @@ public class TypedSelect<T> extends CustomField<T> {
         if (bic != null) {
             bic.setCollection(options);
         } else {
-            bic = new ListContainer<T>(options);
+            bic = new ListContainer<>(options);
         }
         getSelect().setContainerDataSource(bic);
         return this;

--- a/src/main/java/org/vaadin/viritin/fields/config/OptionGroupConfig.java
+++ b/src/main/java/org/vaadin/viritin/fields/config/OptionGroupConfig.java
@@ -26,7 +26,7 @@ public class OptionGroupConfig {
 
     public OptionGroupConfig withDisabledItemIds(List<Object> objectList) {
         if (disabledItemIds == null) {
-            disabledItemIds = new HashSet<Object>();
+            disabledItemIds = new HashSet<>();
         }
         disabledItemIds.add(objectList);
         return this;

--- a/src/main/java/org/vaadin/viritin/form/AbstractForm.java
+++ b/src/main/java/org/vaadin/viritin/form/AbstractForm.java
@@ -3,22 +3,22 @@ package org.vaadin.viritin.form;
 import com.vaadin.ui.*;
 import com.vaadin.ui.themes.ValoTheme;
 import com.vaadin.util.ReflectTools;
-import java.io.Serializable;
 import org.vaadin.viritin.BeanBinder;
 import org.vaadin.viritin.MBeanFieldGroup;
 import org.vaadin.viritin.MBeanFieldGroup.FieldGroupListener;
 import org.vaadin.viritin.button.DeleteButton;
 import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.button.PrimaryButton;
+import org.vaadin.viritin.label.RichText;
 import org.vaadin.viritin.layouts.MHorizontalLayout;
 
+import javax.validation.groups.Default;
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import javax.validation.groups.Default;
-import org.vaadin.viritin.label.RichText;
 
 /**
  * Abstract super class for simple editor forms.
@@ -33,6 +33,7 @@ import org.vaadin.viritin.label.RichText;
 public abstract class AbstractForm<T> extends CustomComponent implements
         FieldGroupListener {
 
+    private static final long serialVersionUID = -2368496151988753088L;
     private String modalWindowTitle = "Edit entry";
     private String saveCaption = "Save";
     private String deleteCaption = "Delete";

--- a/src/main/java/org/vaadin/viritin/form/AbstractForm.java
+++ b/src/main/java/org/vaadin/viritin/form/AbstractForm.java
@@ -524,9 +524,9 @@ public abstract class AbstractForm<T> extends CustomComponent implements
     }
 
     private final LinkedHashMap<MBeanFieldGroup.MValidator<T>, Collection<AbstractComponent>> mValidators
-            = new LinkedHashMap<MBeanFieldGroup.MValidator<T>, Collection<AbstractComponent>>();
+            = new LinkedHashMap<>();
 
-    private final Map<Class, AbstractComponent> validatorToErrorTarget = new LinkedHashMap<Class, AbstractComponent>();
+    private final Map<Class, AbstractComponent> validatorToErrorTarget = new LinkedHashMap<>();
 
     private Class<?>[] validationGroups;
 

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -5,7 +5,11 @@ import com.vaadin.data.Property;
 import com.vaadin.data.util.PropertyValueGenerator;
 import org.vaadin.viritin.ListContainer;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -15,6 +19,8 @@ import java.util.*;
  */
 public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
 
+    private static final long serialVersionUID = -8384723868776183241L;
+
     private final Map<String, PropertyValueGenerator<?>> propertyGenerators = new HashMap();
     protected final Class<T> type;
 
@@ -23,6 +29,8 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
      * @param <T>  property data type
      */
     protected static class GeneratedProperty<T> implements Property<T>  {
+
+        private static final long serialVersionUID = -538857801793925329L;
 
         private final Item item;
         private final Object itemId;
@@ -72,6 +80,8 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
      * Item implementation for generated properties.
      */
     protected class GeneratedPropertyItem implements Item {
+
+        private static final long serialVersionUID = 8231832690836075843L;
 
         private final Item wrappedItem;
         private final Object itemId;

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -203,7 +203,7 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
     private <T> Property<T> createProperty(final Item item,
                                            final Object propertyId, final Object itemId,
                                            final PropertyValueGenerator<T> generator) {
-        return new GeneratedProperty<T>(item, propertyId, itemId, generator);
+        return new GeneratedProperty<>(item, propertyId, itemId, generator);
     }
 
     private Item createGeneratedPropertyItem(final Object itemId,

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -23,10 +23,10 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
      */
     protected static class GeneratedProperty<T> implements Property<T>  {
 
-        private Item item;
-        private Object itemId;
-        private Object propertyId;
-        private PropertyValueGenerator<T> generator;
+        private final Item item;
+        private final Object itemId;
+        private final Object propertyId;
+        private final PropertyValueGenerator<T> generator;
 
         public GeneratedProperty(Item item, Object propertyId, Object itemId,
                                  PropertyValueGenerator<T> generator) {
@@ -72,8 +72,8 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
      */
     protected class GeneratedPropertyItem implements Item {
 
-        private Item wrappedItem;
-        private Object itemId;
+        private final Item wrappedItem;
+        private final Object itemId;
 
         protected GeneratedPropertyItem(Object itemId, Item item) {
             this.itemId = itemId;

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -20,6 +20,7 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
 
     /**
      * Property implementation for generated properties
+     * @param <T>  property data type
      */
     protected static class GeneratedProperty<T> implements Property<T>  {
 

--- a/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
+++ b/src/main/java/org/vaadin/viritin/grid/GeneratedPropertyListContainer.java
@@ -28,7 +28,7 @@ public class GeneratedPropertyListContainer<T> extends ListContainer<T> {
         private final Object propertyId;
         private final PropertyValueGenerator<T> generator;
 
-        public GeneratedProperty(Item item, Object propertyId, Object itemId,
+        GeneratedProperty(Item item, Object propertyId, Object itemId,
                                  PropertyValueGenerator<T> generator) {
             this.item = item;
             this.itemId = itemId;

--- a/src/main/java/org/vaadin/viritin/grid/MGrid.java
+++ b/src/main/java/org/vaadin/viritin/grid/MGrid.java
@@ -326,19 +326,7 @@ public class MGrid<T> extends Grid {
                             "updateRowData", Object.class);
                     method.invoke(extension, bean);
                     break;
-                } catch (NoSuchMethodException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (SecurityException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (IllegalAccessException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (IllegalArgumentException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (InvocationTargetException ex) {
+                } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
                     Logger.getLogger(MGrid.class.getName()).
                             log(Level.SEVERE, null, ex);
                 }
@@ -378,19 +366,7 @@ public class MGrid<T> extends Grid {
                             "refreshCache");
                     method.invoke(extension);
                     break;
-                } catch (NoSuchMethodException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (SecurityException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (IllegalAccessException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (IllegalArgumentException ex) {
-                    Logger.getLogger(MGrid.class.getName()).
-                            log(Level.SEVERE, null, ex);
-                } catch (InvocationTargetException ex) {
+                } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
                     Logger.getLogger(MGrid.class.getName()).
                             log(Level.SEVERE, null, ex);
                 }

--- a/src/main/java/org/vaadin/viritin/grid/MGrid.java
+++ b/src/main/java/org/vaadin/viritin/grid/MGrid.java
@@ -1,6 +1,18 @@
 package org.vaadin.viritin.grid;
 
-import static org.vaadin.viritin.LazyList.DEFAULT_PAGE_SIZE;
+import com.vaadin.data.Container;
+import com.vaadin.data.Item;
+import com.vaadin.data.fieldgroup.FieldGroup;
+import com.vaadin.data.util.PropertyValueGenerator;
+import com.vaadin.event.SortEvent;
+import com.vaadin.event.SortEvent.SortListener;
+import com.vaadin.server.Extension;
+import com.vaadin.ui.Grid;
+import org.vaadin.viritin.LazyList;
+import org.vaadin.viritin.ListContainer;
+import org.vaadin.viritin.MSize;
+import org.vaadin.viritin.SortableLazyList;
+import org.vaadin.viritin.grid.utils.GridUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -10,26 +22,15 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.vaadin.viritin.LazyList;
-import org.vaadin.viritin.ListContainer;
-import org.vaadin.viritin.MSize;
-import org.vaadin.viritin.SortableLazyList;
-import org.vaadin.viritin.grid.utils.GridUtils;
-
-import com.vaadin.data.util.PropertyValueGenerator;
-import com.vaadin.data.Container;
-import com.vaadin.data.Item;
-import com.vaadin.data.fieldgroup.FieldGroup;
-import com.vaadin.event.SortEvent;
-import com.vaadin.event.SortEvent.SortListener;
-import com.vaadin.server.Extension;
-import com.vaadin.ui.Grid;
+import static org.vaadin.viritin.LazyList.DEFAULT_PAGE_SIZE;
 
 /**
  *
  * @param <T> the entity type listed in the Grid
  */
 public class MGrid<T> extends Grid {
+
+    private static final long serialVersionUID = -7821775220281254054L;
 
     private Class<T> typeOfRows;
 
@@ -123,6 +124,8 @@ public class MGrid<T> extends Grid {
     private void ensureSortListener() {
         if (sortListener == null) {
             sortListener = new SortEvent.SortListener() {
+                private static final long serialVersionUID = -8850456663417023533L;
+                
                 @Override
                 public void sort(SortEvent event) {
                     refreshVisibleRows();
@@ -282,6 +285,8 @@ public class MGrid<T> extends Grid {
     protected void ensureRowRefreshListener(boolean isEnabled) {
         if (isEnabled && reloadDataEfficientlyAfterEditor == null) {
             reloadDataEfficientlyAfterEditor = new FieldGroup.CommitHandler() {
+                private static final long serialVersionUID = -9107206992771475209L;
+                
                 @Override
                 public void preCommit(FieldGroup.CommitEvent commitEvent) throws FieldGroup.CommitException {
                 }

--- a/src/main/java/org/vaadin/viritin/grid/TypedPropertyValueGenerator.java
+++ b/src/main/java/org/vaadin/viritin/grid/TypedPropertyValueGenerator.java
@@ -15,6 +15,8 @@ import java.io.Serializable;
  */
 public class TypedPropertyValueGenerator<M, P> extends PropertyValueGenerator<P> {
 
+    private static final long serialVersionUID = 1250403117667296988L;
+
     protected Class<M> modelType;
     protected Class<P> presentationType;
     protected ValueGenerator<M, P> valueGenerator;

--- a/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
+++ b/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
@@ -1,11 +1,5 @@
 package org.vaadin.viritin.grid.utils;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.vaadin.viritin.util.BrowserCookie;
-import org.vaadin.viritin.util.BrowserCookie.Callback;
-
 import com.vaadin.data.sort.SortOrder;
 import com.vaadin.event.SortEvent;
 import com.vaadin.shared.data.sort.SortDirection;
@@ -13,6 +7,11 @@ import com.vaadin.ui.Grid;
 import com.vaadin.ui.Grid.Column;
 import com.vaadin.ui.Grid.ColumnReorderEvent;
 import org.apache.commons.lang3.StringUtils;
+import org.vaadin.viritin.util.BrowserCookie;
+import org.vaadin.viritin.util.BrowserCookie.Callback;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Use this class to save grid hidden columns to cookies. Use {@link #attachToGrid(Grid, String)

--- a/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
+++ b/src/main/java/org/vaadin/viritin/grid/utils/GridUtils.java
@@ -113,7 +113,7 @@ public class GridUtils {
         Callback saveFunc = new Callback() {
             @Override
             public void onValueDetected(String value) {
-                List<SortOrder> sortOrderList = new ArrayList<SortOrder>();
+                List<SortOrder> sortOrderList = new ArrayList<>();
                 if (!StringUtils.isEmpty(value)) {
                     String[] sortOrder = value.split(SEMI_COLOMN_DELIMITER);
                     for (String so : sortOrder) {

--- a/src/main/java/org/vaadin/viritin/label/RichText.java
+++ b/src/main/java/org/vaadin/viritin/label/RichText.java
@@ -17,12 +17,13 @@ package org.vaadin.viritin.label;
 
 import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.Label;
-import java.io.IOException;
-import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 import org.markdown4j.Markdown4jProcessor;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * XSS safe rich text label with either Markdown syntax or raw html (sanitized

--- a/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
@@ -12,6 +12,8 @@ import java.util.Collection;
 
 public class MHorizontalLayout extends HorizontalLayout {
 
+    private static final long serialVersionUID = 524957578263653250L;
+
     public MHorizontalLayout() {
         super.setSpacing(true);
     }

--- a/src/main/java/org/vaadin/viritin/layouts/MMarginInfo.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MMarginInfo.java
@@ -5,6 +5,8 @@ import com.vaadin.shared.ui.MarginInfo;
 
 public class MMarginInfo extends MarginInfo {
 
+    private static final long serialVersionUID = -3559703824387291269L;
+
     public MMarginInfo(boolean enabled) {
         super(enabled);
     }

--- a/src/main/java/org/vaadin/viritin/layouts/MPanel.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MPanel.java
@@ -10,6 +10,8 @@ import org.vaadin.viritin.MSize;
  */
 public class MPanel extends Panel{
 
+    private static final long serialVersionUID = -7384406421724902867L;
+
     public MPanel() {
         super();
     }

--- a/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
+++ b/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 
 public class MVerticalLayout extends VerticalLayout {
 
+    private static final long serialVersionUID = -1806208156595232451L;
+
     public MVerticalLayout() {
         super.setSpacing(true);
         super.setMargin(true);

--- a/src/main/java/org/vaadin/viritin/navigator/MNavigator.java
+++ b/src/main/java/org/vaadin/viritin/navigator/MNavigator.java
@@ -39,6 +39,8 @@ import com.vaadin.ui.UI;
  */
 public class MNavigator extends Navigator {
 
+    private static final long serialVersionUID = 1438630556557157686L;
+
     /**
      * Creates a navigator that is tracking the active view using URI fragments
      * of the {@link com.vaadin.server.Page} containing the given UI and
@@ -137,6 +139,8 @@ public class MNavigator extends Navigator {
     // The listener exists for the life-time of the navigator. It never
     // gets unregistered.
     private static class MViewChangeListener implements ViewChangeListener {
+
+        private static final long serialVersionUID = -3311491180251673472L;
 
         @Override
         public boolean beforeViewChange(ViewChangeListener.ViewChangeEvent event) {

--- a/src/main/java/org/vaadin/viritin/util/BrowserCookie.java
+++ b/src/main/java/org/vaadin/viritin/util/BrowserCookie.java
@@ -3,6 +3,7 @@ package org.vaadin.viritin.util;
 import com.vaadin.ui.JavaScript;
 import com.vaadin.ui.JavaScriptFunction;
 import elemental.json.JsonArray;
+
 import java.util.UUID;
 
 /**
@@ -29,6 +30,7 @@ public class BrowserCookie {
     public static void detectCookieValue(String key, final Callback callback) {
         final String callbackid = "viritincookiecb"+UUID.randomUUID().toString().substring(0,8);
         JavaScript.getCurrent().addFunction(callbackid, new JavaScriptFunction() {
+            private static final long serialVersionUID = -3426072590182105863L;
 
             @Override
             public void call(JsonArray arguments) {

--- a/src/main/java/org/vaadin/viritin/util/HtmlElementPropertySetter.java
+++ b/src/main/java/org/vaadin/viritin/util/HtmlElementPropertySetter.java
@@ -16,6 +16,8 @@ import com.vaadin.ui.AbstractComponent;
 @com.vaadin.annotations.JavaScript("viritin.js")
 public class HtmlElementPropertySetter extends AbstractJavaScriptExtension {
 
+    private static final long serialVersionUID = 6463148772177927232L;
+
     public HtmlElementPropertySetter(AbstractComponent c) {
         extend(c);
     }

--- a/src/main/java/org/vaadin/viritin/util/Java7LocaleNegotiationStrategy.java
+++ b/src/main/java/org/vaadin/viritin/util/Java7LocaleNegotiationStrategy.java
@@ -13,7 +13,7 @@ public class Java7LocaleNegotiationStrategy implements
     public Locale negotiate(final List<Locale> supportedLocales,
             VaadinRequest vaadinRequest) {
         String languages = vaadinRequest.getHeader("Accept-Language");
-        ArrayList<Locale> preferredArray = new ArrayList<Locale>(
+        ArrayList<Locale> preferredArray = new ArrayList<>(
                 supportedLocales);
         if (languages != null) {
             final String[] priorityList = languages.split(",");

--- a/src/main/java/org/vaadin/viritin/util/Java7LocaleNegotiationStrategy.java
+++ b/src/main/java/org/vaadin/viritin/util/Java7LocaleNegotiationStrategy.java
@@ -1,10 +1,13 @@
 package org.vaadin.viritin.util;
 
-import java.util.*;
-
+import com.vaadin.server.VaadinRequest;
 import org.vaadin.viritin.util.VaadinLocale.LocaleNegotiationStrategey;
 
-import com.vaadin.server.VaadinRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
 
 public class Java7LocaleNegotiationStrategy implements
         LocaleNegotiationStrategey {

--- a/src/main/java/org/vaadin/viritin/util/Java8LocaleNegotiationStrategy.java
+++ b/src/main/java/org/vaadin/viritin/util/Java8LocaleNegotiationStrategy.java
@@ -6,6 +6,7 @@ import java.util.*;
 import org.vaadin.viritin.util.VaadinLocale.LocaleNegotiationStrategey;
 
 import com.vaadin.server.VaadinRequest;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Implementation of {@link LocaleNegotiationStrategey} which uses java 1.8
@@ -30,7 +31,7 @@ public class Java8LocaleNegotiationStrategy implements
             Method lookup = Locale.class.getMethod("lookup", List.class,
                     Collection.class);
             return (Locale) lookup.invoke(null, priorityList, supportedLocales);
-        } catch (Exception e) {
+        } catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException e) {
             throw new RuntimeException(
                     "Java8LocaleNegotiontionStrategy need java 1.8 or newer.",
                     e);

--- a/src/main/java/org/vaadin/viritin/util/Java8LocaleNegotiationStrategy.java
+++ b/src/main/java/org/vaadin/viritin/util/Java8LocaleNegotiationStrategy.java
@@ -1,12 +1,13 @@
 package org.vaadin.viritin.util;
 
-import java.lang.reflect.Method;
-import java.util.*;
-
+import com.vaadin.server.VaadinRequest;
 import org.vaadin.viritin.util.VaadinLocale.LocaleNegotiationStrategey;
 
-import com.vaadin.server.VaadinRequest;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Implementation of {@link LocaleNegotiationStrategey} which uses java 1.8

--- a/src/main/java/org/vaadin/viritin/util/SimpleLocaleNegotiationStrategy.java
+++ b/src/main/java/org/vaadin/viritin/util/SimpleLocaleNegotiationStrategy.java
@@ -1,10 +1,11 @@
 package org.vaadin.viritin.util;
 
-import java.util.*;
-
+import com.vaadin.server.VaadinRequest;
 import org.vaadin.viritin.util.VaadinLocale.LocaleNegotiationStrategey;
 
-import com.vaadin.server.VaadinRequest;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Simple implementation of {@link LocaleNegotiationStrategey} which works with

--- a/src/main/java/org/vaadin/viritin/util/VaadinLocale.java
+++ b/src/main/java/org/vaadin/viritin/util/VaadinLocale.java
@@ -38,7 +38,7 @@ public class VaadinLocale {
     }
 
     private static final String LOCALE_SESSION_ATTRIBUTE = "org.vaadin.viritin.selectedLocale";
-    private final List<Locale> supportedLocales = new ArrayList<Locale>();
+    private final List<Locale> supportedLocales = new ArrayList<>();
     private Locale bestLocaleByAcceptHeader;
     private final LocaleNegotiationStrategey localeNegotiationStrategey;
 
@@ -121,7 +121,7 @@ public class VaadinLocale {
     }
 
     private void recursiveSetLocale() {
-        Stack<Component> stack = new Stack<Component>();
+        Stack<Component> stack = new Stack<>();
         stack.addAll(VaadinSession.getCurrent().getUIs());
         while (!stack.isEmpty()) {
             Component component = stack.pop();
@@ -155,6 +155,6 @@ public class VaadinLocale {
     }
 
     public List<Locale> getSupportedLocales() {
-        return new ArrayList<Locale>(supportedLocales);
+        return new ArrayList<>(supportedLocales);
     }
 }

--- a/src/main/java/org/vaadin/viritin/util/VaadinLocale.java
+++ b/src/main/java/org/vaadin/viritin/util/VaadinLocale.java
@@ -1,9 +1,14 @@
 package org.vaadin.viritin.util;
 
-import java.util.*;
-
 import com.vaadin.server.*;
 import com.vaadin.ui.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Stack;
 
 /**
  * This class handles the locale for a vaadin application. It negotiates the

--- a/src/test/java/org/vaadin/viritin/DynaBeanBasedContainerTest.java
+++ b/src/test/java/org/vaadin/viritin/DynaBeanBasedContainerTest.java
@@ -42,7 +42,7 @@ public class DynaBeanBasedContainerTest {
 
     final static int amount = 1000000;
 
-    private List<Person> persons = Service.getListOfPersons(amount);
+    private final List<Person> persons = Service.getListOfPersons(amount);
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/src/test/java/org/vaadin/viritin/DynaBeanBasedContainerTest.java
+++ b/src/test/java/org/vaadin/viritin/DynaBeanBasedContainerTest.java
@@ -49,10 +49,10 @@ public class DynaBeanBasedContainerTest {
 
     @Test
     public void testEmptyList() {
-        List<Person> l = new ArrayList<Person>();
+        List<Person> l = new ArrayList<>();
         // Test with BeanItemContainer
         System.out.println("BeanItemContainer with empty list");
-        BeanItemContainer<Person> bc = new BeanItemContainer<Person>(
+        BeanItemContainer<Person> bc = new BeanItemContainer<>(
                 Person.class, l);
         System.out.println("   container size=" + bc.size());
         System.out.print("Properties: ");
@@ -63,7 +63,7 @@ public class DynaBeanBasedContainerTest {
         // Test ListContainer with setCollection call
         System.out.
                 println("\n\nListContainer with empty list via setCollection");
-        ListContainer<Person> lc = new ListContainer<Person>(Person.class);
+        ListContainer<Person> lc = new ListContainer<>(Person.class);
         lc.setCollection(l);
         System.out.println("   container size=" + lc.size());
         System.out.print("Properties: ");
@@ -74,7 +74,7 @@ public class DynaBeanBasedContainerTest {
         // Test ListContainer with setCollection call
         System.out.println(
                 "\n\nListContainer with Class<T>, Collection<T> constructor");
-        lc = new ListContainer<Person>(Person.class, l);
+        lc = new ListContainer<>(Person.class, l);
         System.out.println("   container size=" + lc.size());
         System.out.print("Properties: ");
         for (String p : lc.getContainerPropertyIds()) {
@@ -98,8 +98,8 @@ public class DynaBeanBasedContainerTest {
         // will cause zarro properties
         System.out.println(
                 "\n\nListContainer with empty list via Collection<T> constructor");
-        l = new ArrayList<Person>();
-        lc = new ListContainer<Person>(l);
+        l = new ArrayList<>();
+        lc = new ListContainer<>(l);
         System.out.println("   container size=" + lc.size());
         System.out.println("Properties: none should print due to exception");
         Assert.assertEquals(0, lc.getContainerPropertyIds().size());
@@ -112,7 +112,7 @@ public class DynaBeanBasedContainerTest {
         long initial = reportMemoryUsage();
 
         long ms = System.currentTimeMillis();
-        ListContainer lc = new ListContainer<Person>(persons);
+        ListContainer lc = new ListContainer<>(persons);
         System.out.println(
                 "After creation (took " + (System.currentTimeMillis() - ms) + ")");
         long after = reportMemoryUsage();
@@ -146,7 +146,7 @@ public class DynaBeanBasedContainerTest {
         long initial = reportMemoryUsage();
 
         long ms = System.currentTimeMillis();
-        BeanItemContainer lc = new BeanItemContainer<Person>(persons);
+        BeanItemContainer lc = new BeanItemContainer<>(persons);
         System.out.println(
                 "After creation (took " + (System.currentTimeMillis() - ms) + ")");
         long after = reportMemoryUsage();
@@ -195,7 +195,7 @@ public class DynaBeanBasedContainerTest {
     public void ensureNullFromNextAndPrevId() {
         final List<Person> persons = Service.getListOfPersons(2);
 
-        ListContainer lc = new ListContainer<Person>(persons);
+        ListContainer lc = new ListContainer<>(persons);
         
         Assert.assertNull(lc.prevItemId(persons.get(0)));
         Assert.assertEquals(persons.get(0), lc.prevItemId(persons.get(1)));

--- a/src/test/java/org/vaadin/viritin/DynaBeanItemTest.java
+++ b/src/test/java/org/vaadin/viritin/DynaBeanItemTest.java
@@ -16,7 +16,7 @@ public class DynaBeanItemTest {
     public void testReturnedPropertyInstances() {
         final Person robin = new Person(0, "Dick", "Grayson", 12);
         final ListContainer<Person> listContainer =
-                new ListContainer<Person>(
+                new ListContainer<>(
                         Person.class,
                         Arrays.asList(robin));
 

--- a/src/test/java/org/vaadin/viritin/FilterableListContainerTest.java
+++ b/src/test/java/org/vaadin/viritin/FilterableListContainerTest.java
@@ -48,7 +48,7 @@ public class FilterableListContainerTest {
     Random r = new Random(0);
 
     private List<Person> getListOfPersons(int total) {
-        List<Person> l = new ArrayList<Person>(total);
+        List<Person> l = new ArrayList<>(total);
         for (int i = 0; i < total; i++) {
             Person p = new Person();
             p.setFirstName("First" + i);
@@ -69,7 +69,7 @@ public class FilterableListContainerTest {
     @Test
     public void clearFilters() {
         final List<Person> listOfPersons = getListOfPersons(100);
-        FilterableListContainer<Person> container = new FilterableListContainer<Person>(
+        FilterableListContainer<Person> container = new FilterableListContainer<>(
                 listOfPersons);
         container.addContainerFilter(new SimpleStringFilter("firstName",
                 "First1", true, true));
@@ -101,7 +101,7 @@ public class FilterableListContainerTest {
         long initial = reportMemoryUsage();
 
         long ms = System.currentTimeMillis();
-        FilterableListContainer<Person> lc = new FilterableListContainer<Person>(
+        FilterableListContainer<Person> lc = new FilterableListContainer<>(
                 persons);
         System.out.println(
                 "After creation with " + amount + " beans (took " + (System.
@@ -122,7 +122,7 @@ public class FilterableListContainerTest {
         long initial = reportMemoryUsage();
 
         long ms = System.currentTimeMillis();
-        BeanItemContainer<Person> lc = new BeanItemContainer<Person>(
+        BeanItemContainer<Person> lc = new BeanItemContainer<>(
                 Person.class, persons);
         System.out.println(
                 "After creation with " + amount + " beans (took " + (System.
@@ -137,7 +137,7 @@ public class FilterableListContainerTest {
 
     @Test
     public void testSortingWhenFiltered() {
-        FilterableListContainer<Person> lc = new FilterableListContainer<Person>(
+        FilterableListContainer<Person> lc = new FilterableListContainer<>(
                 persons);
         lc.addContainerFilter(new SimpleStringFilter("firstName",
                 "First10000", true, true));
@@ -209,8 +209,8 @@ public class FilterableListContainerTest {
 
    @Test
    public void testFirstLast() {
-       FilterableListContainer<Person> lc = new FilterableListContainer<Person>(
-               new ArrayList<Person>(Arrays.asList(
+       FilterableListContainer<Person> lc = new FilterableListContainer<>(
+               new ArrayList<>(Arrays.asList(
                    new Person(0, "1", "1", 1),
                    new Person(0, "2", "2", 2),
                    new Person(0, "3", "3", 3)
@@ -229,8 +229,8 @@ public class FilterableListContainerTest {
 
   @Test
   public void testMultiLevelSort() throws Exception {
-    FilterableListContainer<Person> lc = new FilterableListContainer<Person>(
-          new ArrayList<Person>(Arrays.asList(
+    FilterableListContainer<Person> lc = new FilterableListContainer<>(
+          new ArrayList<>(Arrays.asList(
                 new Person(0, "2", "2", 3),
                 new Person(0, "3", "2", 2),
                 new Person(0, "1", "2", 2),

--- a/src/test/java/org/vaadin/viritin/FilterableListContainerTest.java
+++ b/src/test/java/org/vaadin/viritin/FilterableListContainerTest.java
@@ -62,9 +62,9 @@ public class FilterableListContainerTest {
     final static int amount = 1000000;
     //final static int amount = 100000;
 
-    private Filter ageFilter = new Between("age", 30, 40);
+    private final Filter ageFilter = new Between("age", 30, 40);
 
-    private List<Person> persons = getListOfPersons(amount);
+    private final List<Person> persons = getListOfPersons(amount);
 
     @Test
     public void clearFilters() {

--- a/src/test/java/org/vaadin/viritin/LazyComboBoxUsage.java
+++ b/src/test/java/org/vaadin/viritin/LazyComboBoxUsage.java
@@ -43,6 +43,8 @@ public class LazyComboBoxUsage {
         
         cb.addMValueChangeListener(new MValueChangeListener<Person>() {
 
+            private static final long serialVersionUID = -659661563076688180L;
+
             @Override
             public void valueChange(MValueChangeEvent<Person> event) {
                 selectedValue.setValue(event.getValue());

--- a/src/test/java/org/vaadin/viritin/LazyComboBoxUsage.java
+++ b/src/test/java/org/vaadin/viritin/LazyComboBoxUsage.java
@@ -69,7 +69,7 @@ public class LazyComboBoxUsage {
             if(last > list.size()) {
                 last = list.size();
             }
-            return new ArrayList<Person>(list.subList(startIndex, last));
+            return new ArrayList<>(list.subList(startIndex, last));
         }
         
         private List<Person> findPersons(String filter) {

--- a/src/test/java/org/vaadin/viritin/ListContainerLoopPerformanceTest.java
+++ b/src/test/java/org/vaadin/viritin/ListContainerLoopPerformanceTest.java
@@ -51,7 +51,7 @@ public class ListContainerLoopPerformanceTest {
         NullOutputStream nullOutputStream = new NullOutputStream();
         List<Person> listOfPersons = Service.getListOfPersons(100 * 1000);
         long currentTimeMillis = System.currentTimeMillis();
-        ListContainer<Person> listContainer = new ListContainer<Person>(
+        ListContainer<Person> listContainer = new ListContainer<>(
                 listOfPersons);
         Collection<?> ids = listContainer.getContainerPropertyIds();
         for (int i = 0; i < listContainer.size(); i++) {
@@ -74,7 +74,7 @@ public class ListContainerLoopPerformanceTest {
 
         List<Person> listOfPersons = Service.getListOfPersons(100 * 1000);
         long currentTimeMillis = System.currentTimeMillis();
-        BeanItemContainer<Person> c = new BeanItemContainer<Person>(
+        BeanItemContainer<Person> c = new BeanItemContainer<>(
                 Person.class, listOfPersons);
         Collection<?> ids = c.getContainerPropertyIds();
         for (int i = 0; i < c.size(); i++) {

--- a/src/test/java/org/vaadin/viritin/MBeanFieldGroupTest.java
+++ b/src/test/java/org/vaadin/viritin/MBeanFieldGroupTest.java
@@ -37,7 +37,7 @@ public class MBeanFieldGroupTest {
         // Force en_US as default for test purpose
         Locale.setDefault(Locale.US);
 
-        MBeanFieldGroup fieldGroup = new MBeanFieldGroup<Tester>(Tester.class);
+        MBeanFieldGroup fieldGroup = new MBeanFieldGroup<>(Tester.class);
         Field<?> defaultMessageField = fieldGroup.buildAndBind("defaultMessage");
         Field<?> customMessageKeyField = fieldGroup.buildAndBind("customMessageKey");
         Field<?> customMessageField = fieldGroup.buildAndBind("customMessage");
@@ -50,7 +50,7 @@ public class MBeanFieldGroupTest {
     @Test
     public void notNullAnnotatedFieldsShouldHaveInterpolatedErrorMessageWithLocale() {
         Locale locale = Locale.ITALIAN;
-        MBeanFieldGroup fieldGroup = new MBeanFieldGroup<Tester>(Tester.class);
+        MBeanFieldGroup fieldGroup = new MBeanFieldGroup<>(Tester.class);
         Field<?> defaultMessageField = fieldGroup.buildAndBind("defaultMessage");
         Field<?> customMessageKeyField = fieldGroup.buildAndBind("customMessageKey");
         Field<?> customMessageField = fieldGroup.buildAndBind("customMessage");

--- a/src/test/java/org/vaadin/viritin/MGridTest.java
+++ b/src/test/java/org/vaadin/viritin/MGridTest.java
@@ -20,7 +20,7 @@ public class MGridTest {
         List<Person> listOfPersons = Service.getListOfPersons(100);
         final Person selectedDude = listOfPersons.get(2);
 
-        MGrid<Person> g = new MGrid<Person>();
+        MGrid<Person> g = new MGrid<>();
         // Awesome, now the API actually tells you what you should pass as 
         // parameters and what you'll get as return type.
         g.setRows(listOfPersons);

--- a/src/test/java/org/vaadin/viritin/MultiSelectMadnesInCore.java
+++ b/src/test/java/org/vaadin/viritin/MultiSelectMadnesInCore.java
@@ -29,6 +29,7 @@ public class MultiSelectMadnesInCore {
 
     public static class PersonFormWithCoreTable extends AbstractForm {
 
+        private static final long serialVersionUID = -4766609148902175465L;
         private Table groups = new Table();
 
         public PersonFormWithCoreTable() {
@@ -179,6 +180,7 @@ public class MultiSelectMadnesInCore {
 
     public static class PersonForm extends AbstractForm<Person> {
 
+        private static final long serialVersionUID = 6410815033625409608L;
         MultiSelectTable<Group> groups = new MultiSelectTable()
                 .setOptions(Service.getAvailableGroups());
 

--- a/src/test/java/org/vaadin/viritin/MultiSelectMadnesInCore.java
+++ b/src/test/java/org/vaadin/viritin/MultiSelectMadnesInCore.java
@@ -34,7 +34,7 @@ public class MultiSelectMadnesInCore {
         public PersonFormWithCoreTable() {
             setEagerValidation(true);
             groups.setMultiSelect(true);
-            groups.setContainerDataSource(new ListContainer<Group>(Service.
+            groups.setContainerDataSource(new ListContainer<>(Service.
                     getAvailableGroups()));
             Class c = groups.getType();
 

--- a/src/test/java/org/vaadin/viritin/MultiSelectMadnesInCore.java
+++ b/src/test/java/org/vaadin/viritin/MultiSelectMadnesInCore.java
@@ -67,7 +67,7 @@ public class MultiSelectMadnesInCore {
                             try {
                                 originalCollection = (Collection) c.
                                         newInstance();
-                            } catch (Exception ex) {
+                            } catch (IllegalAccessException | InstantiationException ex) {
                                 throw new RuntimeException(
                                         "Unsupported collection type", ex);
                             }
@@ -133,7 +133,7 @@ public class MultiSelectMadnesInCore {
                                     newInstance();
                             col.addAll(set);
                             return col;
-                        } catch (Exception ex) {
+                        } catch (IllegalAccessException | InstantiationException ex) {
                             throw new RuntimeException(
                                     "Unsupported collection type",
                                     ex);

--- a/src/test/java/org/vaadin/viritin/NestedPropertyTest.java
+++ b/src/test/java/org/vaadin/viritin/NestedPropertyTest.java
@@ -47,7 +47,7 @@ public class NestedPropertyTest {
         private List<Detail> detailList = Arrays.asList(new Detail(),
                 new Detail());
 
-        private Map<String, Integer> stringToInteger = new HashMap<String, Integer>();
+        private Map<String, Integer> stringToInteger = new HashMap<>();
 
         public Entity() {
             stringToInteger.put("id", id.intValue());
@@ -181,7 +181,7 @@ public class NestedPropertyTest {
     @Test
     public void testDynaBeanItem() {
 
-        DynaBeanItem<Entity> dynaBeanItem = new DynaBeanItem<Entity>(
+        DynaBeanItem<Entity> dynaBeanItem = new DynaBeanItem<>(
                 new Entity());
 
         Property itemProperty = dynaBeanItem.getItemProperty("property");
@@ -274,13 +274,13 @@ public class NestedPropertyTest {
     }
 
     public static ListContainer<Entity> getTestListContainer() {
-        ListContainer<Entity> listContainer = new ListContainer<Entity>(
+        ListContainer<Entity> listContainer = new ListContainer<>(
                 getEntities(3));
         return listContainer;
     }
 
     public static List<Entity> getEntities(int n) {
-        ArrayList<Entity> arrayList = new ArrayList<Entity>();
+        ArrayList<Entity> arrayList = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             final Entity entity = new Entity();
             if(i==1) {

--- a/src/test/java/org/vaadin/viritin/NullEntryComparator.java
+++ b/src/test/java/org/vaadin/viritin/NullEntryComparator.java
@@ -32,14 +32,14 @@ public class NullEntryComparator {
     
     @Test
     public void test() {
-        ArrayList<Person> arrayList = new ArrayList<Person>();
+        ArrayList<Person> arrayList = new ArrayList<>();
         Person person = new Person();
         person.setFirstName("Matti");
         arrayList.add(person);
         person = new Person();
         person.setFirstName(null);
         arrayList.add(person);
-        ListContainer<Person> listContainer = new ListContainer<Person>(arrayList);
+        ListContainer<Person> listContainer = new ListContainer<>(arrayList);
         listContainer.sort(new Object[]{"firstName"}, new boolean[]{false});
         
     }

--- a/src/test/java/org/vaadin/viritin/NumberFieldWidthTest.java
+++ b/src/test/java/org/vaadin/viritin/NumberFieldWidthTest.java
@@ -33,6 +33,7 @@ public class NumberFieldWidthTest {
     public void testSizeDefined() {
 
         IntegerField integerField = new IntegerField() {
+            private static final long serialVersionUID = -2915829267538851760L;
 
             @Override
             public void setWidth(float width, Sizeable.Unit unit) {

--- a/src/test/java/org/vaadin/viritin/TableUsageExample.java
+++ b/src/test/java/org/vaadin/viritin/TableUsageExample.java
@@ -35,6 +35,8 @@ public class TableUsageExample {
                 .withColumnHeaders("Property 1", "Second");
         t.addMValueChangeListener(new MValueChangeListener<Entity>() {
 
+            private static final long serialVersionUID = 382491506910830168L;
+
             @Override
             public void valueChange(MValueChangeEvent<Entity> event) {
                 editEntity(event.getValue());

--- a/src/test/java/org/vaadin/viritin/TableUsageExample.java
+++ b/src/test/java/org/vaadin/viritin/TableUsageExample.java
@@ -14,7 +14,7 @@ public class TableUsageExample {
 
     public void tableAsBeanSelector() {
         Table table = new Table();
-        BeanItemContainer<Entity> beanItemContainer = new BeanItemContainer<Entity>(Entity.class);
+        BeanItemContainer<Entity> beanItemContainer = new BeanItemContainer<>(Entity.class);
         beanItemContainer.addAll(findBeans());
         table.setContainerDataSource(beanItemContainer);
         table.setVisibleColumns("property", "another");

--- a/src/test/java/org/vaadin/viritin/TypedSelectUsage.java
+++ b/src/test/java/org/vaadin/viritin/TypedSelectUsage.java
@@ -4,7 +4,6 @@ import com.vaadin.data.Property;
 import com.vaadin.shared.ui.combobox.FilteringMode;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.ListSelect;
-import com.vaadin.ui.TwinColSelect;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,6 +40,7 @@ public class TypedSelectUsage {
 
     private MValueChangeListener<Person> getValueChangeListener() {
         return new MValueChangeListener<Person>() {
+            private static final long serialVersionUID = -9022394310035020509L;
 
             @Override
             public void valueChange(MValueChangeEvent<Person> event) {
@@ -65,6 +65,7 @@ public class TypedSelectUsage {
         // for caption usage
         listSelect.addItems(getOptions());
         listSelect.addValueChangeListener(new Property.ValueChangeListener() {
+            private static final long serialVersionUID = -382717228031608542L;
 
             @Override
             public void valueChange(Property.ValueChangeEvent event) {
@@ -79,6 +80,7 @@ public class TypedSelectUsage {
         // This is partly why the current API is "suboptimal".
         //listSelect.setMultiSelect(true);
         listSelect.addValueChangeListener(new Property.ValueChangeListener() {
+            private static final long serialVersionUID = -382717228031608542L;
 
             @Override
             public void valueChange(Property.ValueChangeEvent event) {
@@ -103,6 +105,7 @@ public class TypedSelectUsage {
         // for most objects you want to customize the caption text. Again, you
         // can use chaind invocation and you'll use lambdas in you java 8 project.
         typedSelect.setCaptionGenerator(new CaptionGenerator<Person>() {
+            private static final long serialVersionUID = -4723489976732288325L;
 
             @Override
             public String getCaption(Person option) {

--- a/src/test/java/org/vaadin/viritin/TypedSelectUsage.java
+++ b/src/test/java/org/vaadin/viritin/TypedSelectUsage.java
@@ -91,7 +91,7 @@ public class TypedSelectUsage {
         /** Actual TypedSelect usage */
 
         // Better typed alternative for Vaadin select
-        final TypedSelect<Person> typedSelect = new TypedSelect<Person>();
+        final TypedSelect<Person> typedSelect = new TypedSelect<>();
         // Uses "NativeSelect" as impl. by default, but all core select types are
         // supported. E.g.: withSelectType(ListSelect.class);
 
@@ -132,7 +132,7 @@ public class TypedSelectUsage {
         // other configuration's are similar to testTypedSelect...
 
         /** Actual TypedSelect usage */
-        final TypedSelect<Person> typedSelect = new TypedSelect<Person>();
+        final TypedSelect<Person> typedSelect = new TypedSelect<>();
         // TypedSelect only provides configurations that are similar to all select-types (AbstractSelect)
         // for example the ComboBox has some options that other AbstractSelect don't have
         // by using asComboBoxType instead of typedSelect.withSelectType(ComboBox.class)

--- a/src/test/java/org/vaadin/viritin/it/CheckBoxGroupTest.java
+++ b/src/test/java/org/vaadin/viritin/it/CheckBoxGroupTest.java
@@ -21,8 +21,12 @@ import org.vaadin.viritin.testdomain.Service;
  */
 @Theme("valo")
 public class CheckBoxGroupTest extends AbstractTest {
+
+    private static final long serialVersionUID = 9030446735101247343L;
     
     public static class PersonForm extends AbstractForm<Person> {
+
+        private static final long serialVersionUID = 663449825951264623L;
         
         private MTextField firstName = new MTextField("Name");
         
@@ -34,6 +38,7 @@ public class CheckBoxGroupTest extends AbstractTest {
         private final CheckBoxGroup<Group> groups = new CheckBoxGroup<Group>()
                 .setOptions(Service.getAvailableGroups())
                 .setCaptionGenerator(new CaptionGenerator<Group>() {
+                    private static final long serialVersionUID = -7476461236123873375L;
                     
                     @Override
                     public String getCaption(Group option) {
@@ -58,6 +63,8 @@ public class CheckBoxGroupTest extends AbstractTest {
         
         form.addValidityChangedListener(
                 new AbstractForm.ValidityChangedListener<Person>() {
+                    private static final long serialVersionUID = -3688956596748617476L;
+                    
                     @Override
                     public void onValidityChanged(
                             AbstractForm.ValidityChangedEvent<Person> event) {
@@ -75,6 +82,7 @@ public class CheckBoxGroupTest extends AbstractTest {
         form.setEntity(p);
         
         form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+            private static final long serialVersionUID = 1008970415395369248L;
             
             @Override
             public void onSave(Person entity) {

--- a/src/test/java/org/vaadin/viritin/it/CheckBoxGroupTest.java
+++ b/src/test/java/org/vaadin/viritin/it/CheckBoxGroupTest.java
@@ -28,7 +28,7 @@ public class CheckBoxGroupTest extends AbstractTest {
         
         private MTextField age = new MTextField("Age");
         
-        private LabelField<Integer> id = new LabelField<Integer>(Integer.class)
+        private LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");
         
         private final CheckBoxGroup<Group> groups = new CheckBoxGroup<Group>()

--- a/src/test/java/org/vaadin/viritin/it/CrossFieldValidation.java
+++ b/src/test/java/org/vaadin/viritin/it/CrossFieldValidation.java
@@ -123,14 +123,14 @@ public class CrossFieldValidation extends AbstractTest {
 
     public static class ReservationForm extends AbstractForm<Reservation> {
 
-        private MTextField comment = new MTextField("Comment");
-        private DateField start = new MDateField("Start")
+        private final MTextField comment = new MTextField("Comment");
+        private final DateField start = new MDateField("Start")
                 .withResolution(Resolution.MINUTE);
-        private DateField end = new MDateField("End")
+        private final DateField end = new MDateField("End")
                 .withResolution(Resolution.MINUTE);
-        private MTextField email = new MTextField("Email");
-        private MTextField verifyEmail = new MTextField("Verify email");
-        private EnumSelect testEnum = new EnumSelect("Test enum");
+        private final MTextField email = new MTextField("Email");
+        private final MTextField verifyEmail = new MTextField("Verify email");
+        private final EnumSelect testEnum = new EnumSelect("Test enum");
 
         public ReservationForm() {
             // In this test using via AbstractForm but can be used with raw

--- a/src/test/java/org/vaadin/viritin/it/CrossFieldValidation.java
+++ b/src/test/java/org/vaadin/viritin/it/CrossFieldValidation.java
@@ -123,6 +123,7 @@ public class CrossFieldValidation extends AbstractTest {
 
     public static class ReservationForm extends AbstractForm<Reservation> {
 
+        private static final long serialVersionUID = -8641811916424288855L;
         private final MTextField comment = new MTextField("Comment");
         private final DateField start = new MDateField("Start")
                 .withResolution(Resolution.MINUTE);
@@ -170,6 +171,8 @@ public class CrossFieldValidation extends AbstractTest {
         public static class MValidatorImpl implements
                 MBeanFieldGroup.MValidator<Reservation> {
 
+            private static final long serialVersionUID = 7773475835262158065L;
+
             @Override
             public void validate(Reservation value) throws Validator.InvalidValueException {
                 // No null checks needed as this is not reached unless
@@ -196,6 +199,8 @@ public class CrossFieldValidation extends AbstractTest {
 
         form.addValidityChangedListener(
                 new AbstractForm.ValidityChangedListener<Reservation>() {
+                    private static final long serialVersionUID = 5430174280044587676L;
+
                     @Override
                     public void onValidityChanged(
                             AbstractForm.ValidityChangedEvent<Reservation> event) {
@@ -211,6 +216,8 @@ public class CrossFieldValidation extends AbstractTest {
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Reservation>() {
 
+            private static final long serialVersionUID = 382987534900227025L;
+
             @Override
             public void onSave(Reservation entity) {
                 Notification.show(entity.toString());
@@ -218,6 +225,8 @@ public class CrossFieldValidation extends AbstractTest {
         });
 
         form.setDeleteHandler(new AbstractForm.DeleteHandler<Reservation>() {
+
+            private static final long serialVersionUID = 427652068306119517L;
 
             @Override
             public void onDelete(Reservation entity) {

--- a/src/test/java/org/vaadin/viritin/it/DisclosurePanelExample.java
+++ b/src/test/java/org/vaadin/viritin/it/DisclosurePanelExample.java
@@ -16,6 +16,8 @@ import org.vaadin.viritin.layouts.MVerticalLayout;
 @Theme("valo")
 public class DisclosurePanelExample extends AbstractTest {
 
+    private static final long serialVersionUID = 2638100034569162593L;
+
     @Override
     public Component getTestComponent() {
         

--- a/src/test/java/org/vaadin/viritin/it/EditDude.java
+++ b/src/test/java/org/vaadin/viritin/it/EditDude.java
@@ -30,11 +30,11 @@ public class EditDude extends AbstractTest {
 
         private MTextField age = new MTextField("Age");
 
-        LabelField<Integer> id = new LabelField<Integer>(Integer.class)
+        LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");
         
         @PropertyId("address.type")
-        EnumSelect<Address.AddressType> type = new EnumSelect<Address.AddressType>();
+        EnumSelect<Address.AddressType> type = new EnumSelect<>();
         @PropertyId("address.street")
         MTextField street = new MTextField().withInputPrompt("street");
         @PropertyId("address.city")

--- a/src/test/java/org/vaadin/viritin/it/EditDude.java
+++ b/src/test/java/org/vaadin/viritin/it/EditDude.java
@@ -23,8 +23,11 @@ import org.vaadin.viritin.testdomain.Dude;
 @Theme("valo")
 public class EditDude extends AbstractTest {
 
+    private static final long serialVersionUID = -1808409887708900997L;
 
     public static class DudeForm extends AbstractForm<Dude> {
+
+        private static final long serialVersionUID = -3578950068291730479L;
 
         private final MTextField firstName = new MTextField("Name");
 
@@ -66,6 +69,7 @@ public class EditDude extends AbstractTest {
         form.setEntity(p);
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Dude>() {
+            private static final long serialVersionUID = 6646955460224852274L;
 
             @Override
             public void onSave(Dude entity) {

--- a/src/test/java/org/vaadin/viritin/it/EditDude.java
+++ b/src/test/java/org/vaadin/viritin/it/EditDude.java
@@ -26,9 +26,9 @@ public class EditDude extends AbstractTest {
 
     public static class DudeForm extends AbstractForm<Dude> {
 
-        private MTextField firstName = new MTextField("Name");
+        private final MTextField firstName = new MTextField("Name");
 
-        private MTextField age = new MTextField("Age");
+        private final MTextField age = new MTextField("Age");
 
         LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");

--- a/src/test/java/org/vaadin/viritin/it/EditPerson.java
+++ b/src/test/java/org/vaadin/viritin/it/EditPerson.java
@@ -20,7 +20,6 @@ import org.vaadin.viritin.testdomain.Address;
 import org.vaadin.viritin.testdomain.Group;
 import org.vaadin.viritin.testdomain.Person;
 import org.vaadin.viritin.testdomain.Service;
-import org.vaadin.viritin.util.HtmlElementPropertySetter;
 
 /**
  *
@@ -28,6 +27,8 @@ import org.vaadin.viritin.util.HtmlElementPropertySetter;
  */
 @Theme("valo")
 public class EditPerson extends AbstractTest {
+
+    private static final long serialVersionUID = 8480545478837182696L;
 
     public static class AddressRow {
 
@@ -42,6 +43,7 @@ public class EditPerson extends AbstractTest {
             // you can do whatwever you want here
             type.setCaptionGenerator(
                     new CaptionGenerator<Address.AddressType>() {
+                        private static final long serialVersionUID = -5994389052707708278L;
 
                         @Override
                         public String getCaption(Address.AddressType option) {
@@ -52,6 +54,8 @@ public class EditPerson extends AbstractTest {
     }
 
     public static class PersonForm extends AbstractForm<Person> {
+
+        private static final long serialVersionUID = -2299890309080845494L;
 
         private final MTextField firstName = new MTextField("Name")
                 .withAutocompleteOff()
@@ -91,6 +95,8 @@ public class EditPerson extends AbstractTest {
 
         form.addValidityChangedListener(
                 new AbstractForm.ValidityChangedListener<Person>() {
+                    private static final long serialVersionUID = -3688956596748617476L;
+                    
                     @Override
                     public void onValidityChanged(
                             AbstractForm.ValidityChangedEvent<Person> event) {
@@ -108,6 +114,7 @@ public class EditPerson extends AbstractTest {
         form.setEntity(p);
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+            private static final long serialVersionUID = 1008970415395369248L;
 
             @Override
             public void onSave(Person entity) {
@@ -116,6 +123,7 @@ public class EditPerson extends AbstractTest {
         });
 
         form.setDeleteHandler(new AbstractForm.DeleteHandler<Person>() {
+            private static final long serialVersionUID = -6298152846013943120L;
 
             @Override
             public void onDelete(Person entity) {
@@ -125,6 +133,7 @@ public class EditPerson extends AbstractTest {
 
         Button openInPopup = new Button("Open in popup");
         openInPopup.addClickListener(new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
 
             @Override
             public void buttonClick(Button.ClickEvent event) {
@@ -134,6 +143,7 @@ public class EditPerson extends AbstractTest {
                 form.setEntity(p);
 
                 form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+                    private static final long serialVersionUID = 1008970415395369248L;
 
                     @Override
                     public void onSave(Person entity) {
@@ -142,6 +152,7 @@ public class EditPerson extends AbstractTest {
                 });
 
                 form.setDeleteHandler(new AbstractForm.DeleteHandler<Person>() {
+                    private static final long serialVersionUID = -6298152846013943120L;
 
                     @Override
                     public void onDelete(Person entity) {
@@ -149,6 +160,7 @@ public class EditPerson extends AbstractTest {
                     }
                 });
                 form.setResetHandler(new AbstractForm.ResetHandler<Person>() {
+                    private static final long serialVersionUID = -1695108652595021734L;
 
                     @Override
                     public void onReset(Person entity) {

--- a/src/test/java/org/vaadin/viritin/it/EditPerson.java
+++ b/src/test/java/org/vaadin/viritin/it/EditPerson.java
@@ -53,16 +53,16 @@ public class EditPerson extends AbstractTest {
 
     public static class PersonForm extends AbstractForm<Person> {
 
-        private MTextField firstName = new MTextField("Name")
+        private final MTextField firstName = new MTextField("Name")
                 .withAutocompleteOff()
                 .withAutoCorrectOff()
                 .withAutoCapitalizeOff()
                 .withSpellCheckOff()
                 ;
 
-        private IntegerField age = new IntegerField("Age");
+        private final IntegerField age = new IntegerField("Age");
 
-        private LabelField<Integer> id = new LabelField<>(Integer.class)
+        private final LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");
         private final ElementCollectionField<Address> addresses = new ElementCollectionField<>(
                 Address.class, AddressRow.class).withCaption("Addressess")

--- a/src/test/java/org/vaadin/viritin/it/EditPerson.java
+++ b/src/test/java/org/vaadin/viritin/it/EditPerson.java
@@ -31,7 +31,7 @@ public class EditPerson extends AbstractTest {
 
     public static class AddressRow {
 
-        EnumSelect<Address.AddressType> type = new EnumSelect<Address.AddressType>();
+        EnumSelect<Address.AddressType> type = new EnumSelect<>();
         MTextField street = new MTextField().withInputPrompt("street");
         MTextField city = new MTextField().withInputPrompt("city");
         MTextField zipCode = new MTextField().withInputPrompt("zip");

--- a/src/test/java/org/vaadin/viritin/it/EditPersonWithDisabledField.java
+++ b/src/test/java/org/vaadin/viritin/it/EditPersonWithDisabledField.java
@@ -23,7 +23,7 @@ public class EditPersonWithDisabledField extends AbstractTest {
     
     public class CustomPerson extends Person {
         
-        private String readOnlyFieldInPojo = "fixedValue";
+        private final String readOnlyFieldInPojo = "fixedValue";
 
         public String getReadOnlyFieldInPojo() {
             return readOnlyFieldInPojo;
@@ -33,13 +33,13 @@ public class EditPersonWithDisabledField extends AbstractTest {
 
     public static class PersonForm extends AbstractForm<CustomPerson> {
 
-        private MTextField firstName = new MTextField("Name");
+        private final MTextField firstName = new MTextField("Name");
         
-        private MTextField readOnlyFieldInPojo = new MTextField("Should be RO");
+        private final MTextField readOnlyFieldInPojo = new MTextField("Should be RO");
 
-        private IntegerField age = new IntegerField("Age");
+        private final IntegerField age = new IntegerField("Age");
 
-        private LabelField<Integer> id = new LabelField<>(Integer.class)
+        private final LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");
 
         public PersonForm() {

--- a/src/test/java/org/vaadin/viritin/it/EditPersonWithDisabledField.java
+++ b/src/test/java/org/vaadin/viritin/it/EditPersonWithDisabledField.java
@@ -33,6 +33,7 @@ public class EditPersonWithDisabledField extends AbstractTest {
 
     public static class PersonForm extends AbstractForm<CustomPerson> {
 
+        private static final long serialVersionUID = -2988976182433301844L;
         private final MTextField firstName = new MTextField("Name");
         
         private final MTextField readOnlyFieldInPojo = new MTextField("Should be RO");
@@ -60,7 +61,9 @@ public class EditPersonWithDisabledField extends AbstractTest {
 
         form.addValidityChangedListener(
                 new AbstractForm.ValidityChangedListener<CustomPerson>() {
-            @Override
+                    private static final long serialVersionUID = -8159920971526151534L;
+
+                    @Override
             public void onValidityChanged(
                     AbstractForm.ValidityChangedEvent<CustomPerson> event) {
                 if (event.getComponent().isValid()) {
@@ -79,6 +82,8 @@ public class EditPersonWithDisabledField extends AbstractTest {
         form.setEntity(p);
 
         form.setSavedHandler(new AbstractForm.SavedHandler<CustomPerson>() {
+
+            private static final long serialVersionUID = 722131410583777207L;
 
             @Override
             public void onSave(CustomPerson entity) {

--- a/src/test/java/org/vaadin/viritin/it/ElementCollectionWithPopupEditor.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollectionWithPopupEditor.java
@@ -33,7 +33,8 @@ public class ElementCollectionWithPopupEditor extends AbstractTest {
     }
 
     public static class FullAddressForm extends AbstractForm<Address> {
-        
+
+        private static final long serialVersionUID = 8476434813427628969L;
         EnumSelect type = new EnumSelect("type");
         MTextField street = new MTextField().withInputPrompt("street");
         MTextField city = new MTextField().withInputPrompt("city");
@@ -55,6 +56,7 @@ public class ElementCollectionWithPopupEditor extends AbstractTest {
 
     public static class PersonFormManualAddressAddition<Person> extends AbstractForm {
 
+        private static final long serialVersionUID = -7517054537365246364L;
         private final ElementCollectionField<Address> addresses
                 = new ElementCollectionField<>(Address.class,
                         AddressRow.class).withCaption("Addressess").
@@ -96,6 +98,8 @@ public class ElementCollectionWithPopupEditor extends AbstractTest {
         form.setEntity(p);
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+
+            private static final long serialVersionUID = 5522176287160062623L;
 
             @Override
             public void onSave(Person entity) {

--- a/src/test/java/org/vaadin/viritin/it/ElementCollectionWithPopupEditor.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollectionWithPopupEditor.java
@@ -61,7 +61,7 @@ public class ElementCollectionWithPopupEditor extends AbstractTest {
                 setRequireVerificationForRemoving(true)
                 .setAllowNewElements(false);
 
-        private Button add = new MButton("Add row", new Button.ClickListener() {
+        private final Button add = new MButton("Add row", new Button.ClickListener() {
 
             @Override
             public void buttonClick(Button.ClickEvent event) {

--- a/src/test/java/org/vaadin/viritin/it/ElementCollections.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollections.java
@@ -28,6 +28,8 @@ public class ElementCollections extends AbstractTest {
 
     static AbstractElementCollection.ElementAddedListener<Address> addedListener = new AbstractElementCollection.ElementAddedListener<Address>() {
 
+        private static final long serialVersionUID = 9185802788725574433L;
+
         @Override
         public void elementAdded(
                 AbstractElementCollection.ElementAddedEvent<Address> e) {
@@ -36,6 +38,8 @@ public class ElementCollections extends AbstractTest {
     };
 
     static AbstractElementCollection.ElementRemovedListener<Address> removeListener = new AbstractElementCollection.ElementRemovedListener<Address>() {
+
+        private static final long serialVersionUID = -3928632995123662365L;
 
         @Override
         public void elementRemoved(
@@ -64,6 +68,7 @@ public class ElementCollections extends AbstractTest {
 
     public static class PersonFormManualAddressAddition<Person> extends AbstractForm {
 
+        private static final long serialVersionUID = 8579572690133496196L;
         private final ElementCollectionField<Address> addresses
                 = new ElementCollectionField<>(Address.class,
                         AddressRow2.class).withCaption("Addressess").
@@ -105,6 +110,8 @@ public class ElementCollections extends AbstractTest {
             addresses.setEditorInstantiator(
                     new AbstractElementCollection.Instantiator<AddressRow2>() {
 
+                        private static final long serialVersionUID = -5211408262496520519L;
+
                         @Override
                         public AddressRow2 create() {
                             AddressRow2 addressRow = new AddressRow2();
@@ -127,6 +134,7 @@ public class ElementCollections extends AbstractTest {
 
     public static class PersonForm2<Person> extends AbstractForm {
 
+        private static final long serialVersionUID = 1463453706744010258L;
         private final ElementCollectionTable<Address> addresses
                 = new ElementCollectionTable<Address>(Address.class,
                         AddressRow.class).withCaption(
@@ -152,6 +160,8 @@ public class ElementCollections extends AbstractTest {
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
 
+            private static final long serialVersionUID = 2098273655384131557L;
+
             @Override
             public void onSave(Person entity) {
                 Notification.show(entity.toString());
@@ -163,6 +173,8 @@ public class ElementCollections extends AbstractTest {
         form2.setEntity(p2);
 
         form2.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+
+            private static final long serialVersionUID = -4210316283038307410L;
 
             @Override
             public void onSave(Person entity) {

--- a/src/test/java/org/vaadin/viritin/it/ElementCollections.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollections.java
@@ -65,7 +65,7 @@ public class ElementCollections extends AbstractTest {
     public static class PersonFormManualAddressAddition<Person> extends AbstractForm {
 
         private final ElementCollectionField<Address> addresses
-                = new ElementCollectionField<Address>(Address.class,
+                = new ElementCollectionField<>(Address.class,
                         AddressRow2.class).withCaption("Addressess").
                 setAllowNewElements(false).
                 setAllowRemovingItems(false).
@@ -159,7 +159,7 @@ public class ElementCollections extends AbstractTest {
         });
 
         Person p2 = Service.getPerson();
-        PersonForm2<Person> form2 = new PersonForm2<Person>();
+        PersonForm2<Person> form2 = new PersonForm2<>();
         form2.setEntity(p2);
 
         form2.setSavedHandler(new AbstractForm.SavedHandler<Person>() {

--- a/src/test/java/org/vaadin/viritin/it/ElementCollections.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollections.java
@@ -72,7 +72,7 @@ public class ElementCollections extends AbstractTest {
                 addElementAddedListener(addedListener).
                 addElementRemovedListener(removeListener);
 
-        private Button add = new MButton("Add row", new Button.ClickListener() {
+        private final Button add = new MButton("Add row", new Button.ClickListener() {
 
             @Override
             public void buttonClick(Button.ClickEvent event) {
@@ -80,7 +80,7 @@ public class ElementCollections extends AbstractTest {
                 addresses.addElement(a);
             }
         });
-        private Button remove = new MButton("Remove first",
+        private final Button remove = new MButton("Remove first",
                 new Button.ClickListener() {
 
                     @Override

--- a/src/test/java/org/vaadin/viritin/it/ElementCollections2.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollections2.java
@@ -38,7 +38,7 @@ public class ElementCollections2 extends AbstractTest {
     public static class PersonFormManualAddressAddition<Person> extends AbstractForm {
 
         private final ElementCollectionField<Address> addresses
-                = new ElementCollectionField<Address>(Address.class,
+                = new ElementCollectionField<>(Address.class,
                         AddressRow.class).withCaption("Addressess").
                 setAllowRemovingItems(false).
                 setAllowNewElements(false);

--- a/src/test/java/org/vaadin/viritin/it/ElementCollections2.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollections2.java
@@ -43,7 +43,7 @@ public class ElementCollections2 extends AbstractTest {
                 setAllowRemovingItems(false).
                 setAllowNewElements(false);
 
-        private Button add = new MButton("Add row", new Button.ClickListener() {
+        private final Button add = new MButton("Add row", new Button.ClickListener() {
 
             @Override
             public void buttonClick(Button.ClickEvent event) {

--- a/src/test/java/org/vaadin/viritin/it/ElementCollections2.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementCollections2.java
@@ -3,19 +3,15 @@ package org.vaadin.viritin.it;
 import com.vaadin.annotations.Theme;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
-import com.vaadin.ui.NativeSelect;
 import com.vaadin.ui.Notification;
 import org.vaadin.addonhelpers.AbstractTest;
 import org.vaadin.viritin.button.MButton;
 import org.vaadin.viritin.fields.EnumSelect;
-import org.vaadin.viritin.fields.AbstractElementCollection;
 import org.vaadin.viritin.fields.ElementCollectionField;
-import org.vaadin.viritin.fields.ElementCollectionTable;
 import org.vaadin.viritin.fields.MTextField;
 import org.vaadin.viritin.form.AbstractForm;
 import org.vaadin.viritin.layouts.MVerticalLayout;
 import org.vaadin.viritin.testdomain.Address;
-import org.vaadin.viritin.testdomain.Address.AddressType;
 import org.vaadin.viritin.testdomain.Person;
 import org.vaadin.viritin.testdomain.Service;
 
@@ -25,6 +21,8 @@ import org.vaadin.viritin.testdomain.Service;
  */
 @Theme("valo")
 public class ElementCollections2 extends AbstractTest {
+
+    private static final long serialVersionUID = -5460730598782896469L;
 
     public static class AddressRow {
 
@@ -37,6 +35,8 @@ public class ElementCollections2 extends AbstractTest {
 
     public static class PersonFormManualAddressAddition<Person> extends AbstractForm {
 
+        private static final long serialVersionUID = -1046677761659317105L;
+
         private final ElementCollectionField<Address> addresses
                 = new ElementCollectionField<>(Address.class,
                         AddressRow.class).withCaption("Addressess").
@@ -44,6 +44,7 @@ public class ElementCollections2 extends AbstractTest {
                 setAllowNewElements(false);
 
         private final Button add = new MButton("Add row", new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
 
             @Override
             public void buttonClick(Button.ClickEvent event) {
@@ -73,6 +74,7 @@ public class ElementCollections2 extends AbstractTest {
         form.setEntity(p);
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+            private static final long serialVersionUID = 1008970415395369248L;
 
             @Override
             public void onSave(Person entity) {

--- a/src/test/java/org/vaadin/viritin/it/ElementPropertySetterTest.java
+++ b/src/test/java/org/vaadin/viritin/it/ElementPropertySetterTest.java
@@ -1,21 +1,11 @@
 package org.vaadin.viritin.it;
 
-import com.vaadin.annotations.StyleSheet;
 import com.vaadin.annotations.Theme;
 import com.vaadin.data.Property;
 import com.vaadin.data.Property.ValueChangeListener;
-import com.vaadin.server.ServiceException;
-import com.vaadin.server.SessionInitEvent;
-import com.vaadin.server.SessionInitListener;
-import com.vaadin.server.VaadinService;
-import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.TextField;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.commons.io.IOUtils;
 import org.vaadin.addonhelpers.AbstractTest;
 import org.vaadin.viritin.layouts.MVerticalLayout;
 import org.vaadin.viritin.util.HtmlElementPropertySetter;
@@ -31,7 +21,10 @@ import org.vaadin.viritin.util.HtmlElementPropertySetter;
 @Theme("valo")
 public class ElementPropertySetterTest extends AbstractTest {
 
+    private static final long serialVersionUID = 2226655074762870301L;
+
     private final ValueChangeListener vcl = new ValueChangeListener() {
+        private static final long serialVersionUID = -382717228031608542L;
 
         @Override
         public void valueChange(Property.ValueChangeEvent event) {

--- a/src/test/java/org/vaadin/viritin/it/EnumFieldAsRadioButtonGroup.java
+++ b/src/test/java/org/vaadin/viritin/it/EnumFieldAsRadioButtonGroup.java
@@ -17,6 +17,8 @@ import org.vaadin.viritin.testdomain.Address.AddressType;
 @Theme("valo")
 public class EnumFieldAsRadioButtonGroup extends AbstractTest {
 
+    private static final long serialVersionUID = -825607383677011983L;
+
     @Override
     public Component getTestComponent() {
 

--- a/src/test/java/org/vaadin/viritin/it/FieldMatchValidator.java
+++ b/src/test/java/org/vaadin/viritin/it/FieldMatchValidator.java
@@ -1,5 +1,6 @@
 package org.vaadin.viritin.it;
 
+import java.lang.reflect.InvocationTargetException;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import org.apache.commons.beanutils.BeanUtils;
@@ -34,7 +35,7 @@ public class FieldMatchValidator implements
 
             return firstObj == null && secondObj == null || firstObj != null && firstObj.
                     equals(secondObj);
-        } catch (final Exception ignore) {
+        } catch (final IllegalAccessException | NoSuchMethodException | InvocationTargetException ignore) {
             // ignore
         }
         return true;

--- a/src/test/java/org/vaadin/viritin/it/FilterTablePerson.java
+++ b/src/test/java/org/vaadin/viritin/it/FilterTablePerson.java
@@ -18,7 +18,7 @@ public class FilterTablePerson extends AbstractTest {
 
     @Override
     public Component getTestComponent() {
-        final FilterableTable<Person> table = new FilterableTable<Person>();
+        final FilterableTable<Person> table = new FilterableTable<>();
         table.withProperties("firstName", "lastName", "age");
         table.setBeans(Service.getListOfPersons(200));
 

--- a/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
+++ b/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
@@ -21,6 +21,8 @@ import org.vaadin.viritin.testdomain.Service;
 @Theme("valo")
 public class GeneratedPropertyListContainerExample extends AbstractTest {
 
+    private static final long serialVersionUID = -902463931733502192L;
+
     private final MGrid<Person> fashionableApiGrid = new MGrid<>(Person.class)
             .setRows(Service.getListOfPersons(100))
             .withGeneratedColumn("fullname", p -> p.getFirstName() + " " + p.getLastName())
@@ -49,6 +51,8 @@ public class GeneratedPropertyListContainerExample extends AbstractTest {
     }
 
     public class DetailsGenerator extends PropertyValueGenerator<String> {
+
+        private static final long serialVersionUID = 8617881785960630559L;
 
         @Override
         public String getValue(Item item, Object itemId, Object propertyId) {

--- a/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
+++ b/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
@@ -58,7 +58,9 @@ public class GeneratedPropertyListContainerExample extends AbstractTest {
             if (addresses != null && !addresses.isEmpty()) {
                 displayValue.append("Addresses: ");
                 for (Address address : addresses) {
-                    if (address == null) continue;
+                    if (address == null) {
+                        continue;
+                    }
                     displayValue.append(address.getZipCode());
                     displayValue.append("; ");
                     displayValue.append(address.getCity());

--- a/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
+++ b/src/test/java/org/vaadin/viritin/it/GeneratedPropertyListContainerExample.java
@@ -21,7 +21,7 @@ import org.vaadin.viritin.testdomain.Service;
 @Theme("valo")
 public class GeneratedPropertyListContainerExample extends AbstractTest {
 
-    private MGrid<Person> fashionableApiGrid = new MGrid<>(Person.class)
+    private final MGrid<Person> fashionableApiGrid = new MGrid<>(Person.class)
             .setRows(Service.getListOfPersons(100))
             .withGeneratedColumn("fullname", p -> p.getFirstName() + " " + p.getLastName())
             .withGeneratedColumn("groupnumber", Integer.class, p -> p.getGroups() != null ? p.getGroups().size() : 0)
@@ -29,7 +29,7 @@ public class GeneratedPropertyListContainerExample extends AbstractTest {
             .withProperties("id", "fullname", "groupnumber", "details")
             .withFullWidth();
 
-    private MGrid<Person> legacyApiGrid = new MGrid<>();
+    private final MGrid<Person> legacyApiGrid = new MGrid<>();
 
     @Override
     public Component getTestComponent() {

--- a/src/test/java/org/vaadin/viritin/it/GridLazyLoading.java
+++ b/src/test/java/org/vaadin/viritin/it/GridLazyLoading.java
@@ -19,7 +19,7 @@ public class GridLazyLoading extends AbstractTest {
     @Override
     public Component getTestComponent() {
 
-        MGrid<Person> g = new MGrid<Person>(
+        MGrid<Person> g = new MGrid<>(
                 new LazyList.PagingProvider<Person>() {
 
                     @Override

--- a/src/test/java/org/vaadin/viritin/it/GridLazyLoading.java
+++ b/src/test/java/org/vaadin/viritin/it/GridLazyLoading.java
@@ -1,6 +1,5 @@
 package org.vaadin.viritin.it;
 
-import com.vaadin.annotations.Theme;
 import com.vaadin.ui.Component;
 import java.util.List;
 import org.vaadin.addonhelpers.AbstractTest;
@@ -16,11 +15,14 @@ import org.vaadin.viritin.testdomain.Service;
 //@Theme("valo")
 public class GridLazyLoading extends AbstractTest {
 
+    private static final long serialVersionUID = 7741969263616707523L;
+
     @Override
     public Component getTestComponent() {
 
         MGrid<Person> g = new MGrid<>(
                 new LazyList.PagingProvider<Person>() {
+                    private static final long serialVersionUID = -9072230332041322210L;
 
                     @Override
                     public List<Person> findEntities(int firstRow) {
@@ -29,6 +31,7 @@ public class GridLazyLoading extends AbstractTest {
                     }
                 },
                 new LazyList.CountProvider() {
+                    private static final long serialVersionUID = -6915320247020779461L;
 
                     @Override
                     public int size() {
@@ -36,8 +39,7 @@ public class GridLazyLoading extends AbstractTest {
                     }
                 }
         );
-        //g.setSizeFull();
+        
         return g;
     }
-
 }

--- a/src/test/java/org/vaadin/viritin/it/GridLazyLoadingAndSorting.java
+++ b/src/test/java/org/vaadin/viritin/it/GridLazyLoadingAndSorting.java
@@ -27,7 +27,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
 
         final List<Person> orig = Service.getListOfPersons(1000);
 
-        final MGrid<Person> g = new MGrid<Person>(
+        final MGrid<Person> g = new MGrid<>(
                 new SortableLazyList.SortablePagingProvider<Person>() {
             @Override
             public List<Person> findEntities(int firstRow, boolean sortAscending,
@@ -35,7 +35,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
                 List<Person> listOfPersons = new ArrayList<>(orig);
                 if (property != null) {
 
-                    Collections.sort(listOfPersons, new BeanComparator<Person>(
+                    Collections.sort(listOfPersons, new BeanComparator<>(
                             property));
                     if (!sortAscending) {
                         Collections.reverse(listOfPersons);
@@ -45,7 +45,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
                 if (last > listOfPersons.size()) {
                     last = listOfPersons.size();
                 }
-                return new ArrayList<Person>(listOfPersons.subList(firstRow,
+                return new ArrayList<>(listOfPersons.subList(firstRow,
                         last));
             }
         },
@@ -58,7 +58,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
         }
         );
 
-        final MGrid<Person> g2 = new MGrid<Person>(Person.class);
+        final MGrid<Person> g2 = new MGrid<>(Person.class);
         g2.lazyLoadFrom(
                 new SortableLazyList.SortablePagingProvider<Person>() {
             @Override
@@ -67,7 +67,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
                 List<Person> listOfPersons = new ArrayList<>(orig);
                 if (property != null) {
 
-                    Collections.sort(listOfPersons, new BeanComparator<Person>(
+                    Collections.sort(listOfPersons, new BeanComparator<>(
                             property));
                     if (!sortAscending) {
                         Collections.reverse(listOfPersons);
@@ -77,7 +77,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
                 if (last > listOfPersons.size()) {
                     last = listOfPersons.size();
                 }
-                return new ArrayList<Person>(listOfPersons.subList(firstRow,
+                return new ArrayList<>(listOfPersons.subList(firstRow,
                         last));
             }
         },
@@ -96,7 +96,7 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
                 List<Person> listOfPersons = new ArrayList<>(orig);
                 if (property != null) {
                     
-                    Collections.sort(listOfPersons, new BeanComparator<Person>(
+                    Collections.sort(listOfPersons, new BeanComparator<>(
                             property));
                     if (!sortAscending) {
                         Collections.reverse(listOfPersons);

--- a/src/test/java/org/vaadin/viritin/it/GridLazyLoadingAndSorting.java
+++ b/src/test/java/org/vaadin/viritin/it/GridLazyLoadingAndSorting.java
@@ -29,7 +29,9 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
 
         final MGrid<Person> g = new MGrid<>(
                 new SortableLazyList.SortablePagingProvider<Person>() {
-            @Override
+                    private static final long serialVersionUID = 8990276045925275684L;
+
+                    @Override
             public List<Person> findEntities(int firstRow, boolean sortAscending,
                     String property) {
                 List<Person> listOfPersons = new ArrayList<>(orig);
@@ -51,7 +53,9 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
         },
                 new LazyList.CountProvider() {
 
-            @Override
+                    private static final long serialVersionUID = 6575441260380762210L;
+
+                    @Override
             public int size() {
                 return orig.size();
             }
@@ -61,7 +65,9 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
         final MGrid<Person> g2 = new MGrid<>(Person.class);
         g2.lazyLoadFrom(
                 new SortableLazyList.SortablePagingProvider<Person>() {
-            @Override
+                    private static final long serialVersionUID = 6584091430092559501L;
+
+                    @Override
             public List<Person> findEntities(int firstRow, boolean sortAscending,
                     String property) {
                 List<Person> listOfPersons = new ArrayList<>(orig);
@@ -83,7 +89,9 @@ public class GridLazyLoadingAndSorting extends AbstractTest {
         },
                 new LazyList.CountProvider() {
 
-            @Override
+                    private static final long serialVersionUID = -7613809143021239619L;
+
+                    @Override
             public int size() {
                 return orig.size();
             }

--- a/src/test/java/org/vaadin/viritin/it/GridLazyLoadingEmptyResultset.java
+++ b/src/test/java/org/vaadin/viritin/it/GridLazyLoadingEmptyResultset.java
@@ -24,7 +24,7 @@ public class GridLazyLoadingEmptyResultset extends AbstractTest {
     public Component getTestComponent() {
         final List<Person> listOfPersons = Service.getListOfPersons(0);
 
-        MGrid<Person> g = new MGrid<Person>(Person.class)
+        MGrid<Person> g = new MGrid<>(Person.class)
                 .lazyLoadFrom(
                         new SortableLazyList.SortablePagingProvider<Person>() {
                     @Override
@@ -34,7 +34,7 @@ public class GridLazyLoadingEmptyResultset extends AbstractTest {
                         if (property != null) {
 
                             Collections.sort(listOfPersons,
-                                    new BeanComparator<Person>(
+                                    new BeanComparator<>(
                                             property));
                             if (!sortAscending) {
                                 Collections.reverse(listOfPersons);
@@ -44,7 +44,7 @@ public class GridLazyLoadingEmptyResultset extends AbstractTest {
                         if (last > listOfPersons.size()) {
                             last = listOfPersons.size();
                         }
-                        return new ArrayList<Person>(listOfPersons.subList(
+                        return new ArrayList<>(listOfPersons.subList(
                                 firstRow,
                                 last));
                     }

--- a/src/test/java/org/vaadin/viritin/it/GridLazyLoadingEmptyResultset.java
+++ b/src/test/java/org/vaadin/viritin/it/GridLazyLoadingEmptyResultset.java
@@ -27,7 +27,9 @@ public class GridLazyLoadingEmptyResultset extends AbstractTest {
         MGrid<Person> g = new MGrid<>(Person.class)
                 .lazyLoadFrom(
                         new SortableLazyList.SortablePagingProvider<Person>() {
-                    @Override
+                            private static final long serialVersionUID = 7430568834619612967L;
+
+                            @Override
                     public List<Person> findEntities(int firstRow,
                             boolean sortAscending,
                             String property) {
@@ -51,7 +53,9 @@ public class GridLazyLoadingEmptyResultset extends AbstractTest {
                 },
                         new LazyList.CountProvider() {
 
-                    @Override
+                            private static final long serialVersionUID = 6199527117644735431L;
+
+                            @Override
                     public int size() {
                         return listOfPersons.size();
                     }

--- a/src/test/java/org/vaadin/viritin/it/GridSaveSettingsTest.java
+++ b/src/test/java/org/vaadin/viritin/it/GridSaveSettingsTest.java
@@ -19,7 +19,7 @@ public class GridSaveSettingsTest extends AbstractTest {
                 + " Grid will save your settings in the browser cookies."
                 + " And load them next time you open the view");
 
-        MGrid<Person> table = new MGrid<Person>();
+        MGrid<Person> table = new MGrid<>();
         table.setRows(
                 new Person(1, "Some", "One", 13),
                 new Person(2, "Arni", "Red", 83),

--- a/src/test/java/org/vaadin/viritin/it/GridWithPersons.java
+++ b/src/test/java/org/vaadin/viritin/it/GridWithPersons.java
@@ -13,6 +13,8 @@ import org.vaadin.viritin.testdomain.Service;
  */
 public class GridWithPersons extends AbstractTest {
 
+    private static final long serialVersionUID = 503365638639247756L;
+
     @Override
     public Component getTestComponent() {
 

--- a/src/test/java/org/vaadin/viritin/it/IntegerFieldUsage.java
+++ b/src/test/java/org/vaadin/viritin/it/IntegerFieldUsage.java
@@ -83,12 +83,12 @@ public class IntegerFieldUsage extends AbstractTest {
         
     }
 
-    private TextField normalInteger = new MTextField().withCaption("Integer with basic TextField");
-    private IntegerField integer = new IntegerField().withCaption("Integer");
-    private IntegerField intti = new IntegerField().withCaption("int");
-    private IntegerField validatedInteger = new IntegerField().withCaption(
+    private final TextField normalInteger = new MTextField().withCaption("Integer with basic TextField");
+    private final IntegerField integer = new IntegerField().withCaption("Integer");
+    private final IntegerField intti = new IntegerField().withCaption("int");
+    private final IntegerField validatedInteger = new IntegerField().withCaption(
             "validated");
-    private IntegerSliderField slider = new IntegerSliderField()
+    private final IntegerSliderField slider = new IntegerSliderField()
             .withCaption("Slider")
             .withStep(5) // .withMax(69) // Set automatically from BeanValidation annotations
             // .withMin(-69) // Set automatically from BeanValidation annotations

--- a/src/test/java/org/vaadin/viritin/it/IntegerFieldUsage.java
+++ b/src/test/java/org/vaadin/viritin/it/IntegerFieldUsage.java
@@ -21,6 +21,8 @@ import org.vaadin.viritin.layouts.MVerticalLayout;
  */
 public class IntegerFieldUsage extends AbstractTest {
 
+    private static final long serialVersionUID = -1841759044439831663L;
+
     public static class Domain {
 
         private Integer normalInteger;
@@ -101,6 +103,7 @@ public class IntegerFieldUsage extends AbstractTest {
 
         BeanBinder.bind(domain, this).withEagerValidation(
                 new MBeanFieldGroup.FieldGroupListener<Domain>() {
+            private static final long serialVersionUID = 1901097967848065661L;
 
             boolean wasvalid = true;
 
@@ -120,6 +123,8 @@ public class IntegerFieldUsage extends AbstractTest {
         });
 
         Button show = new Button("Show value", new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
+            
             @Override
             public void buttonClick(Button.ClickEvent event) {
                 Notification.show(domain.toString());
@@ -128,6 +133,7 @@ public class IntegerFieldUsage extends AbstractTest {
 
         Button toggleVisible = new Button("Toggle visibility",
                 new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
             @Override
             public void buttonClick(Button.ClickEvent event) {
                 integer.setVisible(!integer.isVisible());

--- a/src/test/java/org/vaadin/viritin/it/LazyComboBoxUsageSample.java
+++ b/src/test/java/org/vaadin/viritin/it/LazyComboBoxUsageSample.java
@@ -54,6 +54,8 @@ public class LazyComboBoxUsageSample extends AbstractTest {
                 filterablePagingProvider, filterableCountProvider)
                 .setCaptionGenerator(new CaptionGenerator<Person>() {
 
+                    private static final long serialVersionUID = 5611804984518152177L;
+
                     @Override
                     public String getCaption(Person option) {
                         return option.getFirstName() + " " + option.
@@ -61,6 +63,8 @@ public class LazyComboBoxUsageSample extends AbstractTest {
                     }
                 })
                 .setIconGenerator(new IconGenerator<Person>() {
+                    private static final long serialVersionUID = -795330075732173785L;
+
                     @Override
                     public Resource getIcon(Person option) {
                         return FontAwesome.AMBULANCE;
@@ -73,6 +77,8 @@ public class LazyComboBoxUsageSample extends AbstractTest {
         cb.setValue(selection);
 
         cb.addMValueChangeListener(new MValueChangeListener<Person>() {
+
+            private static final long serialVersionUID = -115227386482631657L;
 
             @Override
             public void valueChange(MValueChangeEvent<Person> event) {

--- a/src/test/java/org/vaadin/viritin/it/MBeanFieldGroupRequiredErrorMessage.java
+++ b/src/test/java/org/vaadin/viritin/it/MBeanFieldGroupRequiredErrorMessage.java
@@ -18,6 +18,7 @@ public class MBeanFieldGroupRequiredErrorMessage extends AbstractTest {
     private TextField street ;
 
 
+    @Override
     public Component getTestComponent() {
         street = new TextField();
         street.setLocale(getLocale());

--- a/src/test/java/org/vaadin/viritin/it/MButtonClickListeners.java
+++ b/src/test/java/org/vaadin/viritin/it/MButtonClickListeners.java
@@ -17,12 +17,12 @@ import org.vaadin.viritin.layouts.MVerticalLayout;
 @Theme("valo")
 public class MButtonClickListeners extends AbstractTest {
 
+    private static final long serialVersionUID = -8785308275350618769L;
+
     @Override
     public Component getTestComponent() {
         
         MButton b = new MButton("Say hola");
-//        b.addClickListener(this::sayHola);
-//        b.addClickListener(this::sayHolaOldSchool);
         
         // And the same without lambdas as the project is 1.6 compatible
         b.addClickListener(new MClickListener() {
@@ -33,6 +33,8 @@ public class MButtonClickListeners extends AbstractTest {
             }
         });
         b.addClickListener(new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
+            
             @Override
             public void buttonClick(ClickEvent event) {
                 sayHolaOldSchool(event);

--- a/src/test/java/org/vaadin/viritin/it/MNotificationExapmle.java
+++ b/src/test/java/org/vaadin/viritin/it/MNotificationExapmle.java
@@ -33,12 +33,16 @@ import org.vaadin.viritin.ui.MNotification;
 @Theme("valo")
 public class MNotificationExapmle extends AbstractTest {
 
+    private static final long serialVersionUID = 1298981554296094891L;
+
     @Override
     public Component getTestComponent() {
         MVerticalLayout layout = new MVerticalLayout(
                 new MLabel("MNotification Examples").withStyleName("h1"),
                 new MHorizontalLayout(
                         new MButton(FontAwesome.COMMENT, "Humanized", new Button.ClickListener() {
+                            private static final long serialVersionUID = 5019806363620874205L;
+                            
                             @Override
                             public void buttonClick(Button.ClickEvent event) {
                                 MNotification.humanized("Humanized", "This is a humanized notification!")
@@ -46,6 +50,8 @@ public class MNotificationExapmle extends AbstractTest {
                             }
                         }).withStyleName("primary"),
                         new MButton(FontAwesome.TIMES, "Error", new Button.ClickListener() {
+                            private static final long serialVersionUID = 5019806363620874205L;
+                            
                             @Override
                             public void buttonClick(Button.ClickEvent event) {
                                 MNotification.error("Error", "This is an error notification!")
@@ -53,6 +59,8 @@ public class MNotificationExapmle extends AbstractTest {
                             }
                         }).withStyleName("danger"),
                         new MButton(FontAwesome.EXCLAMATION_TRIANGLE, "Warning", new Button.ClickListener() {
+                            private static final long serialVersionUID = 5019806363620874205L;
+                            
                             @Override
                             public void buttonClick(Button.ClickEvent event) {
                                 MNotification.warning("Warning", "This is a warning notification!")
@@ -60,6 +68,8 @@ public class MNotificationExapmle extends AbstractTest {
                             }
                         }),
                         new MButton(FontAwesome.DOWNLOAD, "Tray", new Button.ClickListener() {
+                            private static final long serialVersionUID = 5019806363620874205L;
+                            
                             @Override
                             public void buttonClick(Button.ClickEvent event) {
                                 MNotification.tray("Tray", "This is a tray notification!")
@@ -67,6 +77,8 @@ public class MNotificationExapmle extends AbstractTest {
                             }
                         }).withStyleName("friendly"),
                         new MButton(FontAwesome.WHEELCHAIR, "Assistive", new Button.ClickListener() {
+                            private static final long serialVersionUID = 5019806363620874205L;
+                            
                             @Override
                             public void buttonClick(Button.ClickEvent event) {
                                 MNotification.assistive("Assistive", "This is an assistive notification!");

--- a/src/test/java/org/vaadin/viritin/it/MTableLazyLoading.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableLazyLoading.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.vaadin.addonhelpers.AbstractTest;
 import org.vaadin.viritin.LazyList;
 import org.vaadin.viritin.fields.MTable;
-import org.vaadin.viritin.grid.MGrid;
 import org.vaadin.viritin.testdomain.Person;
 import org.vaadin.viritin.testdomain.Service;
 
@@ -17,11 +16,14 @@ import org.vaadin.viritin.testdomain.Service;
 @Theme("valo")
 public class MTableLazyLoading extends AbstractTest {
 
+    private static final long serialVersionUID = 5350550589682437269L;
+
     @Override
     public Component getTestComponent() {
 
         MTable<Person> g = new MTable<>(
                 new LazyList.PagingProvider<Person>() {
+                    private static final long serialVersionUID = -9072230332041322210L;
 
                     @Override
                     public List<Person> findEntities(int firstRow) {
@@ -30,6 +32,7 @@ public class MTableLazyLoading extends AbstractTest {
                     }
                 },
                 new LazyList.CountProvider() {
+                    private static final long serialVersionUID = -6915320247020779461L;
 
                     @Override
                     public int size() {

--- a/src/test/java/org/vaadin/viritin/it/MTableLazyLoading.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableLazyLoading.java
@@ -20,7 +20,7 @@ public class MTableLazyLoading extends AbstractTest {
     @Override
     public Component getTestComponent() {
 
-        MTable<Person> g = new MTable<Person>(
+        MTable<Person> g = new MTable<>(
                 new LazyList.PagingProvider<Person>() {
 
                     @Override

--- a/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingEmptyList.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingEmptyList.java
@@ -23,14 +23,18 @@ public class MTableLazyLoadingEmptyList extends AbstractTest {
         
         MTable<Person> mTable = new MTable<>(
                 new LazyList.PagingProvider<Person>() {
-                    
+
+                    private static final long serialVersionUID = 4212839156216191152L;
+
                     @Override
                     public List<Person> findEntities(int firstRow) {
                         return backingList.subList(firstRow, 0);
                     }
                 },
                 new LazyList.CountProvider() {
-                    
+
+                    private static final long serialVersionUID = -3958524394327292732L;
+
                     @Override
                     public int size() {
                         return 0;

--- a/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingEmptyList.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingEmptyList.java
@@ -21,7 +21,7 @@ public class MTableLazyLoadingEmptyList extends AbstractTest {
         
         final List<Person> backingList = Service.getListOfPersons(0);
         
-        MTable<Person> mTable = new MTable<Person>(
+        MTable<Person> mTable = new MTable<>(
                 new LazyList.PagingProvider<Person>() {
                     
                     @Override

--- a/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingWithSorting.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingWithSorting.java
@@ -29,7 +29,9 @@ public class MTableLazyLoadingWithSorting extends AbstractTest {
 
         MTable<Person> g = new MTable<>(
                 new SortableLazyList.SortablePagingProvider<Person>() {
-            @Override
+                    private static final long serialVersionUID = 5276735386651186011L;
+
+                    @Override
             public List<Person> findEntities(int firstRow, boolean sortAscending,
                     String property) {
                 List<Person> listOfPersons = new ArrayList<>(orig);
@@ -51,7 +53,9 @@ public class MTableLazyLoadingWithSorting extends AbstractTest {
         },
                 new LazyList.CountProvider() {
 
-            @Override
+                    private static final long serialVersionUID = -3920880835334547231L;
+
+                    @Override
             public int size() {
                 return (int) Service.count();
             }

--- a/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingWithSorting.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableLazyLoadingWithSorting.java
@@ -27,7 +27,7 @@ public class MTableLazyLoadingWithSorting extends AbstractTest {
 
         final List<Person> orig = Service.getListOfPersons(1000);
 
-        MTable<Person> g = new MTable<Person>(
+        MTable<Person> g = new MTable<>(
                 new SortableLazyList.SortablePagingProvider<Person>() {
             @Override
             public List<Person> findEntities(int firstRow, boolean sortAscending,
@@ -35,7 +35,7 @@ public class MTableLazyLoadingWithSorting extends AbstractTest {
                 List<Person> listOfPersons = new ArrayList<>(orig);
                 if (property != null) {
 
-                    Collections.sort(listOfPersons, new BeanComparator<Person>(
+                    Collections.sort(listOfPersons, new BeanComparator<>(
                             property));
                     if (!sortAscending) {
                         Collections.reverse(listOfPersons);
@@ -45,7 +45,7 @@ public class MTableLazyLoadingWithSorting extends AbstractTest {
                 if (last > listOfPersons.size()) {
                     last = listOfPersons.size();
                 }
-                return new ArrayList<Person>(listOfPersons.subList(firstRow,
+                return new ArrayList<>(listOfPersons.subList(firstRow,
                         last));
             }
         },

--- a/src/test/java/org/vaadin/viritin/it/MTableWithNestedProperty.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithNestedProperty.java
@@ -18,6 +18,7 @@ public class MTableWithNestedProperty extends AbstractTest {
 
     public static class Form extends AbstractForm<NestedPropertyTest.Entity> {
 
+        private static final long serialVersionUID = -3164966078873765005L;
         private final TextField property = new MTextField("property");
         // Appears not to work, core issue!? @PropertyId("detail.property")
         private final TextField nestedPropertyField = new MTextField("detail.property");
@@ -56,13 +57,17 @@ public class MTableWithNestedProperty extends AbstractTest {
         form.setSavedHandler(
                 new AbstractForm.SavedHandler<NestedPropertyTest.Entity>() {
 
-            @Override
+                    private static final long serialVersionUID = 5142651230686909799L;
+
+                    @Override
             public void onSave(NestedPropertyTest.Entity entity) {
                 table.refreshRowCache();
             }
         });
         
         table.addMValueChangeListener(new MValueChangeListener<NestedPropertyTest.Entity>() {
+
+            private static final long serialVersionUID = -2918207986940924806L;
 
             @Override
             public void valueChange(

--- a/src/test/java/org/vaadin/viritin/it/MTableWithNestedProperty.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithNestedProperty.java
@@ -18,9 +18,9 @@ public class MTableWithNestedProperty extends AbstractTest {
 
     public static class Form extends AbstractForm<NestedPropertyTest.Entity> {
 
-        private TextField property = new MTextField("property");
+        private final TextField property = new MTextField("property");
         // Appears not to work, core issue!? @PropertyId("detail.property")
-        private TextField nestedPropertyField = new MTextField("detail.property");
+        private final TextField nestedPropertyField = new MTextField("detail.property");
 
         @Override
         protected Component createContent() {

--- a/src/test/java/org/vaadin/viritin/it/MTableWithRowClickListener.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithRowClickListener.java
@@ -16,6 +16,7 @@ public class MTableWithRowClickListener extends AbstractTest {
 
     public static class Form extends AbstractForm<NestedPropertyTest.Entity> {
 
+        private static final long serialVersionUID = -8683293957823897252L;
         private final TextField property = new MTextField("property");
         // Appears not to work, core issue!? @PropertyId("detail.property")
         private final TextField nestedPropertyField = new MTextField("detail.property");
@@ -58,6 +59,8 @@ public class MTableWithRowClickListener extends AbstractTest {
         form.setSavedHandler(
                 new AbstractForm.SavedHandler<NestedPropertyTest.Entity>() {
 
+                    private static final long serialVersionUID = 5841730427136575503L;
+
                     @Override
                     public void onSave(NestedPropertyTest.Entity entity) {
                         table.refreshRowCache();
@@ -66,6 +69,8 @@ public class MTableWithRowClickListener extends AbstractTest {
 
         table.addRowClickListener(
                 new MTable.RowClickListener<NestedPropertyTest.Entity>() {
+
+                    private static final long serialVersionUID = -5651811812313380992L;
 
                     @Override
                     public void rowClick(

--- a/src/test/java/org/vaadin/viritin/it/MTableWithRowClickListener.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithRowClickListener.java
@@ -16,9 +16,9 @@ public class MTableWithRowClickListener extends AbstractTest {
 
     public static class Form extends AbstractForm<NestedPropertyTest.Entity> {
 
-        private TextField property = new MTextField("property");
+        private final TextField property = new MTextField("property");
         // Appears not to work, core issue!? @PropertyId("detail.property")
-        private TextField nestedPropertyField = new MTextField("detail.property");
+        private final TextField nestedPropertyField = new MTextField("detail.property");
 
         @Override
         protected Component createContent() {

--- a/src/test/java/org/vaadin/viritin/it/MTableWithTraditionalPaging.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithTraditionalPaging.java
@@ -23,12 +23,18 @@ import org.vaadin.viritin.testdomain.Service;
 @Theme("valo")
 public class MTableWithTraditionalPaging extends AbstractTest {
 
+    private static final long serialVersionUID = -3645542297869930694L;
+
     /**
      * A quickly drafted version of pagination bar.
      */
     public static class PaginationBar extends MHorizontalLayout {
 
+        private static final long serialVersionUID = 7799263034212965499L;
+
         private final ClickListener handler = new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
+            
             @Override
             public void buttonClick(Button.ClickEvent event) {
                 if (event.getButton() == first) {

--- a/src/test/java/org/vaadin/viritin/it/MTableWithTraditionalPaging.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithTraditionalPaging.java
@@ -28,7 +28,7 @@ public class MTableWithTraditionalPaging extends AbstractTest {
      */
     public static class PaginationBar extends MHorizontalLayout {
 
-        private ClickListener handler = new Button.ClickListener() {
+        private final ClickListener handler = new Button.ClickListener() {
             @Override
             public void buttonClick(Button.ClickEvent event) {
                 if (event.getButton() == first) {

--- a/src/test/java/org/vaadin/viritin/it/MTableWithTraditionalPaging.java
+++ b/src/test/java/org/vaadin/viritin/it/MTableWithTraditionalPaging.java
@@ -109,7 +109,7 @@ public class MTableWithTraditionalPaging extends AbstractTest {
         final int pageSize = 10;
         final long results = Service.count();
 
-        final MTable<Person> table = new MTable<Person>(Person.class);
+        final MTable<Person> table = new MTable<>(Person.class);
         table.setPageLength(10);
         // set the initial content
         table.setBeans(Service.findAll(0, pageSize));

--- a/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithCustomRelationMaintenance.java
+++ b/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithCustomRelationMaintenance.java
@@ -34,7 +34,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
 
         private MTextField age = new MTextField("Age");
 
-        LabelField<Integer> id = new LabelField<Integer>(Integer.class)
+        LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");
         
         private final MultiSelectTable<Group> groups = new MultiSelectTable<Group>(){

--- a/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithCustomRelationMaintenance.java
+++ b/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithCustomRelationMaintenance.java
@@ -4,19 +4,14 @@ import com.vaadin.annotations.Theme;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
-import com.vaadin.ui.themes.ValoTheme;
 import java.util.Set;
 
 import org.vaadin.addonhelpers.AbstractTest;
-import org.vaadin.viritin.fields.CaptionGenerator;
-import org.vaadin.viritin.fields.EnumSelect;
-import org.vaadin.viritin.fields.ElementCollectionField;
 import org.vaadin.viritin.fields.LabelField;
 import org.vaadin.viritin.fields.MTextField;
 import org.vaadin.viritin.fields.MultiSelectTable;
 import org.vaadin.viritin.form.AbstractForm;
 import org.vaadin.viritin.layouts.MVerticalLayout;
-import org.vaadin.viritin.testdomain.Address;
 import org.vaadin.viritin.testdomain.Group;
 import org.vaadin.viritin.testdomain.Person;
 import org.vaadin.viritin.testdomain.Service;
@@ -28,7 +23,11 @@ import org.vaadin.viritin.testdomain.Service;
 @Theme("valo")
 public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest {
 
+    private static final long serialVersionUID = -2682172644856319883L;
+
     public static class PersonForm extends AbstractForm<Person> {
+
+        private static final long serialVersionUID = 4144805837285124445L;
 
         private final MTextField firstName = new MTextField("Name");
 
@@ -38,6 +37,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
                 .withCaption("ID");
         
         private final MultiSelectTable<Group> groups = new MultiSelectTable<Group>(){
+            private static final long serialVersionUID = 1229334178491680961L;
             @Override
             protected void addRelation(Set<Group> newValues) {
                 super.addRelation(newValues);
@@ -83,6 +83,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
 
         form.addValidityChangedListener(
                 new AbstractForm.ValidityChangedListener<Person>() {
+                    private static final long serialVersionUID = -3688956596748617476L;
                     @Override
                     public void onValidityChanged(
                             AbstractForm.ValidityChangedEvent<Person> event) {
@@ -100,6 +101,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
         form.setEntity(p);
 
         form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+            private static final long serialVersionUID = 1008970415395369248L;
 
             @Override
             public void onSave(Person entity) {
@@ -118,6 +120,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
         });
 
         form.setDeleteHandler(new AbstractForm.DeleteHandler<Person>() {
+            private static final long serialVersionUID = -6298152846013943120L;
 
             @Override
             public void onDelete(Person entity) {
@@ -127,6 +130,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
 
         Button openInPopup = new Button("Open in popup");
         openInPopup.addClickListener(new Button.ClickListener() {
+            private static final long serialVersionUID = 5019806363620874205L;
 
             @Override
             public void buttonClick(Button.ClickEvent event) {
@@ -136,6 +140,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
                 form.setEntity(p);
 
                 form.setSavedHandler(new AbstractForm.SavedHandler<Person>() {
+                    private static final long serialVersionUID = 1008970415395369248L;
 
                     @Override
                     public void onSave(Person entity) {
@@ -144,6 +149,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
                 });
 
                 form.setDeleteHandler(new AbstractForm.DeleteHandler<Person>() {
+                    private static final long serialVersionUID = -6298152846013943120L;
 
                     @Override
                     public void onDelete(Person entity) {
@@ -151,6 +157,7 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
                     }
                 });
                 form.setResetHandler(new AbstractForm.ResetHandler<Person>() {
+                    private static final long serialVersionUID = -1695108652595021734L;
 
                     @Override
                     public void onReset(Person entity) {

--- a/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithCustomRelationMaintenance.java
+++ b/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithCustomRelationMaintenance.java
@@ -30,9 +30,9 @@ public class MultiSelectTableWithCustomRelationMaintenance extends AbstractTest 
 
     public static class PersonForm extends AbstractForm<Person> {
 
-        private MTextField firstName = new MTextField("Name");
+        private final MTextField firstName = new MTextField("Name");
 
-        private MTextField age = new MTextField("Age");
+        private final MTextField age = new MTextField("Age");
 
         LabelField<Integer> id = new LabelField<>(Integer.class)
                 .withCaption("ID");

--- a/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithStringCollection.java
+++ b/src/test/java/org/vaadin/viritin/it/MultiSelectTableWithStringCollection.java
@@ -25,7 +25,7 @@ public class MultiSelectTableWithStringCollection extends AbstractTest {
     
     public static class Beani {
         
-        private List<String> strings = new ArrayList<String>();
+        private List<String> strings = new ArrayList<>();
 
         public List<String> getStrings() {
             return strings;

--- a/src/test/java/org/vaadin/viritin/it/PerformanceBeanItemContainer.java
+++ b/src/test/java/org/vaadin/viritin/it/PerformanceBeanItemContainer.java
@@ -18,7 +18,7 @@ import org.vaadin.viritin.testdomain.Person;
 public class PerformanceBeanItemContainer extends AbstractTest {
     @Override
     public Component getTestComponent() {
-        BeanItemContainer<Person> beanItemContainer = new BeanItemContainer<Person>(Person.class, PerformanceListContainer.LIST_OF_PERSONS);
+        BeanItemContainer<Person> beanItemContainer = new BeanItemContainer<>(Person.class, PerformanceListContainer.LIST_OF_PERSONS);
         Table table = new Table();
         table.setContainerDataSource(beanItemContainer, Arrays.asList("firstName", "lastName"));
         return table;

--- a/src/test/java/org/vaadin/viritin/it/PerformanceListContainer.java
+++ b/src/test/java/org/vaadin/viritin/it/PerformanceListContainer.java
@@ -19,7 +19,7 @@ public class PerformanceListContainer extends AbstractTest {
  
     @Override
     public Component getTestComponent() {
-        MTable<Person> mTable = new MTable<Person>(Person.class).withProperties("firstName", "lastName");
+        MTable<Person> mTable = new MTable<>(Person.class).withProperties("firstName", "lastName");
         mTable.setBeans(LIST_OF_PERSONS);
         return mTable;
     }

--- a/src/test/java/org/vaadin/viritin/it/SortingWithCollections.java
+++ b/src/test/java/org/vaadin/viritin/it/SortingWithCollections.java
@@ -46,7 +46,7 @@ public class SortingWithCollections extends AbstractTest {
                          * You could do anything you want here. Here just
                          * use BeanComparator from commons-beanutils
                          */
-                        BeanComparator<Person> beanComparator = new BeanComparator<Person>();
+                        BeanComparator<Person> beanComparator = new BeanComparator<>();
                         beanComparator.setProperty(sortProperty);
                         if(event.isSortAscending()) {
                             return beanComparator.compare(o1, o2);

--- a/src/test/java/org/vaadin/viritin/it/SubSetSelectorExample.java
+++ b/src/test/java/org/vaadin/viritin/it/SubSetSelectorExample.java
@@ -32,6 +32,8 @@ public class SubSetSelectorExample extends AbstractTest {
     @Override
     public Component getTestComponent() {
         SubSetSelector<Person> sss = new SubSetSelector<Person>(Person.class) {
+            private static final long serialVersionUID = 3761463604053463442L;
+
             @Override
             protected Person instantiateOption(String stringInput) {
                 Person person = new Person();
@@ -58,6 +60,7 @@ public class SubSetSelectorExample extends AbstractTest {
         // This is optional and can replace setNewItemsAllowed as well (then new items using + button)
         sss.setNewInstanceForm(new AbstractForm<Person>() {
 
+            private static final long serialVersionUID = 2112187966786117814L;
             MTextField firstName = new MTextField("First name");
             MTextField lastName = new MTextField("Last name");
 

--- a/src/test/java/org/vaadin/viritin/it/examples/ElementCollectionFieldExample.java
+++ b/src/test/java/org/vaadin/viritin/it/examples/ElementCollectionFieldExample.java
@@ -21,8 +21,8 @@ public class ElementCollectionFieldExample extends AbstractTest {
 
     @Override
     public Component getTestComponent() {
-        ElementCollectionField<Person> ecf = new ElementCollectionField<Person>(Person.class, PersonRow.class);
-        ecf.setValue(new ArrayList<Person>());
+        ElementCollectionField<Person> ecf = new ElementCollectionField<>(Person.class, PersonRow.class);
+        ecf.setValue(new ArrayList<>());
         return ecf;
     }
 

--- a/src/test/java/org/vaadin/viritin/it/examples/ElementCollectionFieldExample.java
+++ b/src/test/java/org/vaadin/viritin/it/examples/ElementCollectionFieldExample.java
@@ -13,6 +13,8 @@ import com.vaadin.ui.Component;
 @Theme("valo")
 public class ElementCollectionFieldExample extends AbstractTest {
 
+    private static final long serialVersionUID = 7350047443363548232L;
+
     public static class PersonRow {
         MTextField firstName = new MTextField();
         MTextField lastName = new MTextField();

--- a/src/test/java/org/vaadin/viritin/it/issues/Issue131.java
+++ b/src/test/java/org/vaadin/viritin/it/issues/Issue131.java
@@ -29,6 +29,7 @@ public class Issue131 extends AbstractTest {
     public class Member implements Serializable {
 
         private static final String MEMBER_CODE = "MEM";
+        private static final long serialVersionUID = -4051512128345987991L;
 
         private Long id;
 
@@ -102,6 +103,7 @@ public class Issue131 extends AbstractTest {
 
     public class MemberForm2 extends AbstractForm<Member> {
 
+        private static final long serialVersionUID = 2115224810575804578L;
         final MBeanFieldGroup<Member> fieldGroup;
 
         @PropertyId("initials")
@@ -197,6 +199,8 @@ public class Issue131 extends AbstractTest {
         m.lastName = "Tahvonen";
         final MemberForm2 memberForm2 = new MemberForm2(m);
         memberForm2.setSavedHandler(new AbstractForm.SavedHandler<Member>() {
+            private static final long serialVersionUID = -4100482203816246947L;
+
             @Override
             public void onSave(Member entity) {
                 Notification.show(entity.toString());

--- a/src/test/java/org/vaadin/viritin/it/locale/VaadinLocaleDemo.java
+++ b/src/test/java/org/vaadin/viritin/it/locale/VaadinLocaleDemo.java
@@ -23,11 +23,11 @@ import com.vaadin.ui.Button.ClickListener;
 @SuppressWarnings("serial")
 @Theme("valo")
 public class VaadinLocaleDemo extends AbstractTest {
-    private VaadinLocale vaadinLocale = new VaadinLocale(Locale.ENGLISH,
+    private final VaadinLocale vaadinLocale = new VaadinLocale(Locale.ENGLISH,
             Locale.GERMAN, new Locale("de", "DE"), new Locale("da"), new Locale("fi"));
-    private LocaleSelect localeSelect = (LocaleSelect) new LocaleSelect()
+    private final LocaleSelect localeSelect = (LocaleSelect) new LocaleSelect()
             .withSelectType(ComboBox.class);
-    private DateField dateField = new DateField();
+    private final DateField dateField = new DateField();
 
     @Override
     protected void init(VaadinRequest vaadinRequest) {

--- a/src/test/java/org/vaadin/viritin/it/locale/VaadinLocaleDemoComponent.java
+++ b/src/test/java/org/vaadin/viritin/it/locale/VaadinLocaleDemoComponent.java
@@ -11,7 +11,7 @@ import com.vaadin.ui.*;
  *
  */
 public class VaadinLocaleDemoComponent extends CustomComponent {
-    private DateField dateField = new DateField();
+    private final DateField dateField = new DateField();
 
     public VaadinLocaleDemoComponent() {
         dateField.setValue(new Date());

--- a/src/test/java/org/vaadin/viritin/it/locale/VaadinLocaleTest.java
+++ b/src/test/java/org/vaadin/viritin/it/locale/VaadinLocaleTest.java
@@ -18,7 +18,7 @@ import org.vaadin.addonhelpers.components.VaadinComboBox;
 
 @RunWith(Parameterized.class)
 public class VaadinLocaleTest extends AbstractWebDriverCase {
-    private String expectedLanguage;
+    private final String expectedLanguage;
 
     @Parameters
     public static Collection languages() {

--- a/src/test/java/org/vaadin/viritin/testdomain/Dude.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/Dude.java
@@ -94,27 +94,36 @@ public class Dude {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         Dude other = (Dude) obj;
-        if (ObjectUtils.notEqual(age, other.age))
+        if (ObjectUtils.notEqual(age, other.age)) {
             return false;
+        }
         if (firstName == null) {
-            if (other.firstName != null)
+            if (other.firstName != null) {
                 return false;
-        } else if (!firstName.equals(other.firstName))
+            }
+        } else if (!firstName.equals(other.firstName)) {
             return false;
-        if (id != other.id)
+        }
+        if (id != other.id) {
             return false;
+        }
         if (lastName == null) {
-            if (other.lastName != null)
+            if (other.lastName != null) {
                 return false;
-        } else if (!lastName.equals(other.lastName))
+            }
+        } else if (!lastName.equals(other.lastName)) {
             return false;
+        }
         return true;
     }
 

--- a/src/test/java/org/vaadin/viritin/testdomain/Person.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/Person.java
@@ -36,9 +36,9 @@ public class Person {
     @NotNull
     private Integer age;
 
-    private List<Address> addresses = new ArrayList<Address>();
+    private List<Address> addresses = new ArrayList<>();
 
-    private List<Group> groups = new ArrayList<Group>();
+    private List<Group> groups = new ArrayList<>();
 
     public Person() {
     }

--- a/src/test/java/org/vaadin/viritin/testdomain/Person.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/Person.java
@@ -117,10 +117,7 @@ public class Person {
             return false;
         }
         Person other = (Person) obj;
-        if (id != other.id) {
-            return false;
-        }
-        return true;
+        return id == other.id;
     }
 
     @Override

--- a/src/test/java/org/vaadin/viritin/testdomain/Person.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/Person.java
@@ -107,15 +107,19 @@ public class Person {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         Person other = (Person) obj;
-        if (id != other.id)
+        if (id != other.id) {
             return false;
+        }
         return true;
     }
 

--- a/src/test/java/org/vaadin/viritin/testdomain/Service.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/Service.java
@@ -26,11 +26,11 @@ public class Service {
     }
 
     public static List<Group> getAvailableGroups() {
-        return new ArrayList<Group>(groups);
+        return new ArrayList<>(groups);
     }
 
     public static List<Person> getListOfPersons(int total) {
-        List<Person> l = new ArrayList<Person>(total);
+        List<Person> l = new ArrayList<>(total);
         for (int i = 0; i < total; i++) {
             Person p = new Person();
             p.setId(i + 1);

--- a/src/test/java/org/vaadin/viritin/testdomain/User.java
+++ b/src/test/java/org/vaadin/viritin/testdomain/User.java
@@ -41,6 +41,7 @@ public class User
 		person = personParameter;
 	}
 
+    @Override
 	public Locale getLocale() {
 		return locale;
 	}


### PR DESCRIPTION
I have done some quick improvements to the code. There is still a lot that can be done to make the library cleaner and more future-proof. 

These are the changes I have done:
* MTable is now easier to use with interface-implementation-separated classes
* Javadoc should build without warnings due to missing parameter tags
* Code has been upgraded to Java 7 standard (diamonds, multi-catch, etc)
* Some `Object`-fields that would have resulted in errors if they were not a specific type is now generic
* Some unnescessary code has been removed (casts, public-statements in inner classes, etc)
* All serializable types now have a serialVersionUID-field