### PR TITLE
Forwarding ErrorMessage to "inner" ComboBox

### DIFF
--- a/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
+++ b/src/main/java/org/vaadin/viritin/fields/LazyComboBox.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.vaadin.server.ErrorMessage;
 import org.apache.commons.lang3.ObjectUtils;
 import org.vaadin.viritin.LazyList;
 import org.vaadin.viritin.ListContainer;
@@ -382,4 +383,8 @@ public class LazyComboBox<T> extends TypedSelect<T> {
         return (LazyComboBox<T>) super.withCaption(caption);
     }
 
+    @Override
+    public void setComponentError(ErrorMessage componentError) {
+        getSelect().setComponentError(componentError);
+    }
 }


### PR DESCRIPTION
Hi,

I noticed that a `LazyComboBox` with errors is not styled as expected; in particular the `div` representing the inner combo doesn't have the `v-filterselect-error` class that is applied when a "standalone" ComboBox has errors. The solution I chose is to forward the `ErrorMessage` set by the `setComponentError` method to the inner `ComboBox`. Actually I had considered a couple of other options:

- Overriding the method in `TypedSelect`

- Setting `ErrorMessage` to both `this` (`CustomField`) and `select` instance. This would have been the safest solution in terms of backward compatibility but it didn't look that "clean".

Thank you,

lorenzo