### PR TITLE
Fixes a class cast exception.

### DIFF
--- a/src/main/java/org/vaadin/viritin/ListContainer.java
+++ b/src/main/java/org/vaadin/viritin/ListContainer.java
@@ -494,7 +494,7 @@ public class ListContainer<T> extends AbstractContainer implements
      * @param property the property whose comparator is requested
      * @return Comparator that will compare two objects based on a property
      */
-    protected Comparator<T> getUnderlyingComparator(Object property) {
+    protected Comparator<?> getUnderlyingComparator(Object property) {
         return new NullComparator();
     }
 


### PR DESCRIPTION
I tried to provide my own Comparator and the class cast exception occurred. I checked and saw the property values are passed to the Comparator instead of the bean. It can be seen in line 542 in ListContainer.