### PR TITLE
Added a conccurrent version of the sortable lazy list.

### DIFF
--- a/src/main/java/org/vaadin/viritin/ConcurrentSortableLazyList.java
+++ b/src/main/java/org/vaadin/viritin/ConcurrentSortableLazyList.java
@@ -1,0 +1,104 @@
+package org.vaadin.viritin;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A concurrent version of the {@link SortableLazyList}.
+ * <p>
+ * This implementation locks calls to {@link #size()}, {@link #findEntities(int)}, {@link #initCacheFormPage(int)}
+ * and {@link #get(int)}, enabling access from multiple threads at the same time.
+ *
+ * @param <T> The type of the objects in the list
+ * @author Jesenko Mehmedbasic
+ */
+public class ConcurrentSortableLazyList<T> extends SortableLazyList<T> {
+    private final Lock lock = new ReentrantLock();
+    private long lockDelay = 10_000;
+
+    public ConcurrentSortableLazyList(SortableEntityProvider<T> dataProvider) {
+        super(dataProvider);
+    }
+
+    public ConcurrentSortableLazyList(SortableEntityProvider<T> dataProvider, int pageSize) {
+        super(dataProvider, pageSize);
+    }
+
+    public ConcurrentSortableLazyList(SortablePagingProvider<T> pageProvider, CountProvider countProvider) {
+        super(pageProvider, countProvider);
+    }
+
+    public ConcurrentSortableLazyList(SortablePagingProvider<T> pageProvider, CountProvider countProvider, int pageSize) {
+        super(pageProvider, countProvider, pageSize);
+    }
+
+    public ConcurrentSortableLazyList(MultiSortablePagingProvider<T> pageProvider, CountProvider countProvider, int pageSize) {
+        super(pageProvider, countProvider, pageSize);
+    }
+
+    /**
+     * Sets the amount of time the list waits for a lock.
+     *
+     * @param time the time in milliseconds.
+     */
+    public void setLockDelay(long time) {
+        if (time < 0) {
+            throw new IllegalArgumentException("The time argument must be greater than zero.");
+        }
+        this.lockDelay = time;
+    }
+
+    @Override
+    public int size() {
+        try {
+            tryLock();
+            return super.size();
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    protected List<T> findEntities(int firstRow) {
+        try {
+            tryLock();
+            return super.findEntities(firstRow);
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    public T get(int index) {
+        try {
+            tryLock();
+            return super.get(index);
+        } finally {
+            unlock();
+        }
+    }
+
+    @Override
+    protected void initCacheFormPage(int pageIndexForRequest) {
+        try {
+            tryLock();
+            super.initCacheFormPage(pageIndexForRequest);
+        } finally {
+            unlock();
+        }
+    }
+
+    private void unlock() {
+        lock.unlock();
+    }
+
+    private void tryLock() {
+        try {
+            lock.tryLock(lockDelay, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
We ran into some issues with very fast updates to a MGrid using a ListContainer with a SortableLazyList. 

The issue occurred during a call to `getItemIds` in the list container.
This calls `lazyList.subList()` which, in our application, threw `ArrayIndexOutOfBoundsException`.
This was caused by the list being updated from our datasource (rest service) during an iteration.