### PR TITLE
eagerly pass content to bean in MPasswordField

### DIFF
--- a/src/main/java/org/vaadin/viritin/v7/fields/MPasswordField.java
+++ b/src/main/java/org/vaadin/viritin/v7/fields/MPasswordField.java
@@ -249,10 +249,33 @@ public class MPasswordField extends PasswordField implements EagerValidateable {
             if (!wasvalid) {
                 markAsDirty();
             }
+            // Also eagerly pass content to backing bean to make top level
+            // validation eager, but do not listen the value back in value change
+            // event
+            if (getPropertyDataSource() != null) {
+                skipValueChangeEvent = true;
+                Object convertedValue = ConverterUtil.convertToModel(
+                        getLastKnownTextContent(), getPropertyDataSource().
+                        getType(), getConverter(),
+                        getLocale());
+                getPropertyDataSource().setValue(convertedValue);
+                skipValueChangeEvent = false;
+            }
         } catch (Validator.InvalidValueException e) {
             eagerValidationError = e;
             eagerValidationStatus = false;
             markAsDirty();
+        }
+    }
+
+    private boolean skipValueChangeEvent = false;
+
+    @Override
+    public void valueChange(Property.ValueChangeEvent event) {
+        if (!skipValueChangeEvent) {
+            super.valueChange(event);
+        } else {
+            skipValueChangeEvent = false;
         }
     }
 


### PR DESCRIPTION
made `MPasswordField` eagerly pass content to backed bean in `doEagerValidation`, analog to `MTextField`