### PR TITLE
#321 - Delegate all style related functions directly to the underlying textfield

### DIFF
--- a/viritin/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
+++ b/viritin/src/main/java/org/vaadin/viritin/fields/AbstractNumberField.java
@@ -171,4 +171,60 @@ public abstract class AbstractNumberField<S extends AbstractNumberField<S, T>, T
         return (S) this;
     }
 
+    @Override
+    public String getStyleName() {
+        return tf.getStyleName();
+    }
+
+    @Override
+    public void setStyleName(String style) {
+        tf.setStyleName(style);
+    }
+
+    @Override
+    public void setPrimaryStyleName(String style) {
+        tf.setPrimaryStyleName(style);
+    }
+
+    @Override
+    public String getPrimaryStyleName() {
+        return tf.getPrimaryStyleName();
+    }
+
+    @Override
+    public void addStyleName(String style) {
+        tf.addStyleName(style);
+    }
+
+    @Override
+    public void removeStyleName(String style) {
+        tf.removeStyleName(style);
+    }
+
+    @Override
+    public void setStyleName(String style, boolean add) {
+        tf.setStyleName(style, add);
+    }
+
+    @Override
+    public S withPrimaryStyleName(String style) {
+        tf.setPrimaryStyleName(style);
+        return (S) this;
+    }
+
+    @Override
+    public S withStyleName(String... styles) {
+        tf.addStyleNames(styles);
+        return (S) this;
+    }
+
+    @Override
+    public void addStyleNames(String... styles) {
+        tf.addStyleNames(styles);
+    }
+
+    @Override
+    public void removeStyleNames(String... styles) {
+        tf.removeStyleNames(styles);
+    }
 }

--- a/viritin/src/test/java/org/vaadin/viritin/fields/IntegerFieldTest.java
+++ b/viritin/src/test/java/org/vaadin/viritin/fields/IntegerFieldTest.java
@@ -1,8 +1,12 @@
 package org.vaadin.viritin.fields;
 
-import static org.junit.Assert.*;
+import com.vaadin.ui.themes.ValoTheme;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.*;
-import org.junit.*;
+import static org.junit.Assert.assertThat;
 
 public class IntegerFieldTest {
 
@@ -11,6 +15,7 @@ public class IntegerFieldTest {
     @Before
     public void setUp() throws Exception {
         fieldUnderTest = new IntegerField();
+        fieldUnderTest.addStyleName(ValoTheme.TEXTFIELD_INLINE_ICON);
     }
 
     @Test
@@ -29,6 +34,13 @@ public class IntegerFieldTest {
         fieldUnderTest.userInputToValue("2");
         fieldUnderTest.userInputToValue("");
         assertThat(fieldUnderTest.getValue(), is((Integer) null));
+    }
+
+    @Test
+    public void testTextFieldHasStyles() {
+        assertThat("Underlying textfield is null", fieldUnderTest.tf, notNullValue());
+        Matcher<String> hasStyle = containsString(ValoTheme.TEXTFIELD_INLINE_ICON);
+        assertThat("Underlying textfield does not contain style", fieldUnderTest.tf.getStyleName(), hasStyle);
     }
 
 }


### PR DESCRIPTION
Fixes issue #321.

I have overridden all methods related to add/remove styles and delegated them to the underlying textfield. Also added small test.