### PR TITLE
Generalized expand() function

### DIFF
--- a/viritin/src/main/java/org/vaadin/viritin/fluency/ui/FluentAbstractOrderedLayout.java
+++ b/viritin/src/main/java/org/vaadin/viritin/fluency/ui/FluentAbstractOrderedLayout.java
@@ -6,7 +6,7 @@ import com.vaadin.ui.Component;
 
 /**
  * The base interface for fluent versions of {@link AbstractOrderedLayout}
- * 
+ *
  * @author Daniel Nordhoff-Vergien
  * @see AbstractOrderedLayout
  */
@@ -15,14 +15,13 @@ public interface FluentAbstractOrderedLayout<S extends FluentAbstractLayout<S> &
         FluentLayout.FluentMarginHandler<S>,
         FluentLayout.FluentSpacingHandler<S>, FluentAbstractLayout<S> {
     // Javadoc copied form Vaadin Framework
+
     /**
      * Adds a component into indexed position in this container.
-     * 
-     * @param c
-     *            the component to be added.
-     * @param index
-     *            the index of the component position. The components currently
-     *            in and after the position are shifted forwards.
+     *
+     * @param c     the component to be added.
+     * @param index the index of the component position. The components currently
+     *              in and after the position are shifted forwards.
      * @return this (for method chaining)
      * @see AbstractOrderedLayout#addComponent(Component, int)
      */
@@ -32,12 +31,12 @@ public interface FluentAbstractOrderedLayout<S extends FluentAbstractLayout<S> &
     }
 
     // Javadoc copied form Vaadin Framework
+
     /**
      * Adds a component into this container. The component is added to the left
      * or on top of the other components.
-     * 
-     * @param c
-     *            the component to be added.
+     *
+     * @param c the component to be added.
      * @return this (for method chaining)
      * @see AbstractOrderedLayout#addComponentAsFirst(Component)
      */
@@ -47,44 +46,62 @@ public interface FluentAbstractOrderedLayout<S extends FluentAbstractLayout<S> &
     }
 
     // Javadoc copied form Vaadin Framework
+
     /**
      * <p>
      * This method is used to control how excess space in layout is distributed
      * among components. Excess space may exist if layout is sized and contained
      * non relatively sized components don't consume all available space.
-     * 
+     * <p>
      * <p>
      * Example how to distribute 1:3 (33%) for component1 and 2:3 (67%) for
      * component2 :
-     * 
+     * <p>
      * <code>
      * layout.setExpandRatio(component1, 1);<br>
      * layout.setExpandRatio(component2, 2);
      * </code>
-     * 
+     * <p>
      * <p>
      * If no ratios have been set, the excess space is distributed evenly among
      * all components.
-     * 
+     * <p>
      * <p>
      * Note, that width or height (depending on orientation) needs to be defined
      * for this method to have any effect.
-     * 
-     * @see Sizeable
-     * 
-     * @param component
-     *            the component in this layout which expand ratio is to be set
-     * @param ratio
-     *            new expand ratio (greater or equal to 0)
-     * 
+     *
+     * @param component the component in this layout which expand ratio is to be set
+     * @param ratio     new expand ratio (greater or equal to 0)
      * @return this (for method chaining)
+     * @throws IllegalArgumentException if the expand ratio is negative or the component is not a
+     *                                  direct child of the layout
+     * @see Sizeable
      * @see AbstractOrderedLayout#setExpandRatio(Component, float)
-     * @throws IllegalArgumentException
-     *             if the expand ratio is negative or the component is not a
-     *             direct child of the layout
      */
     public default S withExpandRatio(Component component, float ratio) {
         ((AbstractOrderedLayout) this).setExpandRatio(component, ratio);
+        return (S) this;
+    }
+
+    /**
+     * Expands selected components. Also adds to layout and sets the only sane
+     * height for expanded components (100%) if needed.
+     *
+     * @param componentsToExpand components that should be expanded
+     * @return the object itself for further configuration
+     */
+    public default S expand(Component... componentsToExpand) {
+        if (getHeight() < 0) {
+            // Make full height if no other size is set
+            withFullHeight();
+        }
+        for (Component component : componentsToExpand) {
+            if (component.getParent() != this) {
+                addComponent(component);
+            }
+            withExpandRatio(component, 1);
+            component.setHeight(100, Unit.PERCENTAGE);
+        }
         return (S) this;
     }
 }

--- a/viritin/src/main/java/org/vaadin/viritin/layouts/MFormLayout.java
+++ b/viritin/src/main/java/org/vaadin/viritin/layouts/MFormLayout.java
@@ -1,9 +1,11 @@
 package org.vaadin.viritin.layouts;
 
-import org.vaadin.viritin.fluency.ui.FluentFormLayout;
-
+import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.FormLayout;
+import org.vaadin.viritin.fluency.ui.FluentFormLayout;
+
+import java.util.Collection;
 
 public class MFormLayout extends FormLayout
         implements FluentFormLayout<MFormLayout> {
@@ -16,4 +18,47 @@ public class MFormLayout extends FormLayout
     public MFormLayout(Component... children) {
         super(children);
     }
+
+    public MFormLayout with(Component... components) {
+        addComponents(components);
+        return this;
+    }
+
+    public MFormLayout alignAll(Alignment alignment) {
+        for (Component component : this) {
+            setComponentAlignment(component, alignment);
+        }
+        return this;
+    }
+
+    public MFormLayout add(Component... component) {
+        return with(component);
+    }
+
+    public MFormLayout add(Collection<Component> component) {
+        return with(component.toArray(new Component[component.size()]));
+    }
+
+    public MFormLayout add(Component component, Alignment alignment) {
+        return add(component).withAlign(component, alignment);
+    }
+
+    public MFormLayout add(Component component, float ratio) {
+        return add(component).withExpand(component, ratio);
+    }
+
+    public MFormLayout add(Component component, Alignment alignment, float ratio) {
+        return add(component).withAlign(component, alignment).withExpand(component, ratio);
+    }
+
+    public MFormLayout withAlign(Component component, Alignment alignment) {
+        setComponentAlignment(component, alignment);
+        return this;
+    }
+
+    public MFormLayout withExpand(Component component, float ratio) {
+        setExpandRatio(component, ratio);
+        return this;
+    }
+
 }

--- a/viritin/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
+++ b/viritin/src/main/java/org/vaadin/viritin/layouts/MHorizontalLayout.java
@@ -1,13 +1,12 @@
 package org.vaadin.viritin.layouts;
 
-import java.util.Collection;
-
-import org.vaadin.viritin.fluency.ui.FluentHorizontalLayout;
-
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
+import org.vaadin.viritin.fluency.ui.FluentHorizontalLayout;
+
+import java.util.Collection;
 
 public class MHorizontalLayout extends HorizontalLayout
         implements FluentHorizontalLayout<MHorizontalLayout> {
@@ -30,29 +29,6 @@ public class MHorizontalLayout extends HorizontalLayout
     public MHorizontalLayout alignAll(Alignment alignment) {
         for (Component component : this) {
             setComponentAlignment(component, alignment);
-        }
-        return this;
-    }
-
-    /**
-     * Expands selected components. Also sets the only sane width for expanded
-     * components (100%).
-     *
-     * @param componentsToExpand the components that should be expanded
-     * @return the object itself for further configuration
-     */
-    public MHorizontalLayout expand(Component... componentsToExpand) {
-        if (getWidth() < 0) {
-            // Make full height if no other size is set
-            withFullWidth();
-        }
-
-        for (Component component : componentsToExpand) {
-            if (component.getParent() != this) {
-                addComponent(component);
-            }
-            setExpandRatio(component, 1);
-            component.setWidth(100, Unit.PERCENTAGE);
         }
         return this;
     }

--- a/viritin/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
+++ b/viritin/src/main/java/org/vaadin/viritin/layouts/MVerticalLayout.java
@@ -1,12 +1,11 @@
 package org.vaadin.viritin.layouts;
 
-import java.util.Collection;
-
-import org.vaadin.viritin.fluency.ui.FluentVerticalLayout;
-
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.VerticalLayout;
+import org.vaadin.viritin.fluency.ui.FluentVerticalLayout;
+
+import java.util.Collection;
 
 public class MVerticalLayout extends VerticalLayout
         implements FluentVerticalLayout<MVerticalLayout> {
@@ -29,28 +28,6 @@ public class MVerticalLayout extends VerticalLayout
     public MVerticalLayout alignAll(Alignment alignment) {
         for (Component component : this) {
             setComponentAlignment(component, alignment);
-        }
-        return this;
-    }
-
-    /**
-     * Expands selected components. Also adds to layout and sets the only sane
-     * height for expanded components (100%) if needed.
-     *
-     * @param componentsToExpand components that should be expanded
-     * @return the object itself for further configuration
-     */
-    public MVerticalLayout expand(Component... componentsToExpand) {
-        if (getHeight() < 0) {
-            // Make full height if no other size is set
-            withFullHeight();
-        }
-        for (Component component : componentsToExpand) {
-            if (component.getParent() != this) {
-                addComponent(component);
-            }
-            setExpandRatio(component, 1);
-            component.setHeight(100, Unit.PERCENTAGE);
         }
         return this;
     }


### PR DESCRIPTION
I added the `expand(Component... componentsToExpand)` function to the `FluentAbstractOrderedLayout` interface, that way they can be used in MFormLayout too.

In addition to that, I added the `add(Component... components)` overload methods to MFormLayout, since they are useful there too.