### PR TITLE
Add step attribute support to DoubleField

### DIFF
--- a/viritin/src/main/java/org/vaadin/viritin/fields/DoubleField.java
+++ b/viritin/src/main/java/org/vaadin/viritin/fields/DoubleField.java
@@ -19,11 +19,15 @@ public class DoubleField extends AbstractNumberField<DoubleField, Double> {
 
     private static final long serialVersionUID = 377246000306551089L;
 
+	private String step = "any";
+	private String definedStep;
+
     public DoubleField() {
         setSizeUndefined();
     }
 
     public DoubleField(String caption) {
+        setSizeUndefined();
         setCaption(caption);
     }
 
@@ -49,6 +53,11 @@ public class DoubleField extends AbstractNumberField<DoubleField, Double> {
         return (DoubleField) super.withFocusListener(listener);
     }
 
+	public DoubleField withStep(String step) {
+		this.definedStep = step;
+		return this;
+	}
+
     @Override
     public Double getValue() {
         return value;
@@ -56,6 +65,17 @@ public class DoubleField extends AbstractNumberField<DoubleField, Double> {
 
     @Override
     protected void configureHtmlElement() {
+		if (StringUtils.isNotBlank(definedStep)) {
+			step = definedStep;
+
+		} else if (getValue() != null) {
+			String s = String.valueOf(getValue()).replaceAll("\\d", "0").replaceAll("(\\d{1})$", "1");
+			if ("any".equals(step) || s.length() > step.length()) {
+				step = s;
+			}
+		}
+		s.setProperty("step", step);
+
         s.setProperty("type", getHtmlFieldType());
         // prevent all but numbers or single dot after a number with a simple js
         s.setJavaScriptEventHandler("keypress",

--- a/viritin/src/main/java/org/vaadin/viritin/fields/DoubleField.java
+++ b/viritin/src/main/java/org/vaadin/viritin/fields/DoubleField.java
@@ -20,7 +20,7 @@ public class DoubleField extends AbstractNumberField<DoubleField, Double> {
     private static final long serialVersionUID = 377246000306551089L;
 
 	private String step = "any";
-	private String definedStep;
+	private Double definedStep;
 
     public DoubleField() {
         setSizeUndefined();
@@ -53,7 +53,7 @@ public class DoubleField extends AbstractNumberField<DoubleField, Double> {
         return (DoubleField) super.withFocusListener(listener);
     }
 
-	public DoubleField withStep(String step) {
+	public DoubleField withStep(Double step) {
 		this.definedStep = step;
 		return this;
 	}
@@ -65,8 +65,8 @@ public class DoubleField extends AbstractNumberField<DoubleField, Double> {
 
     @Override
     protected void configureHtmlElement() {
-		if (StringUtils.isNotBlank(definedStep)) {
-			step = definedStep;
+		if (definedStep != null) {
+			step = String.valueOf(definedStep);
 
 		} else if (getValue() != null) {
 			String s = String.valueOf(getValue()).replaceAll("\\d", "0").replaceAll("(\\d{1})$", "1");


### PR DESCRIPTION
The step attribute is defined programmatically with method `withStep(String step)`, or based on user input. 

For example if user enters the value 5.3 then the step will be 0.1. Then he enters the value 5.35 the step will be 0.01. Then he enters the value 5.4 the step will remain at 0.01 etc.