### PR TITLE
SizelessGrid doesn't handle reset correctly

### DIFF
--- a/viritin/src/main/java/org/vaadin/viritin/grid/SizelessDataCommunicator.java
+++ b/viritin/src/main/java/org/vaadin/viritin/grid/SizelessDataCommunicator.java
@@ -40,7 +40,7 @@ public class SizelessDataCommunicator<T> extends DataCommunicator<T> {
             return;
         }
 
-        if (initial) {
+        if (initial || reset) {
             rpc.reset(0);
         }
 


### PR DESCRIPTION
We lost the reset logic from `DataCommunicator`, so but in place again