### PR TITLE
update commons-io from 2.4 to 2.6

### DIFF
--- a/viritin-compatibility/pom.xml
+++ b/viritin-compatibility/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/viritin/pom.xml
+++ b/viritin/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adding viritin to a Vaadin Flow project currently breaks it, because flow server requires `org.apache.commons.io.FileUtils.forceMkdirParent()` from commons-io >= 2.5:
```
Exception sending context initialized event to listener instance of class [com.vaadin.flow.spring.VaadinServletContextInitializer$DevModeServletContextListener]
java.lang.NoSuchMethodError: 'void org.apache.commons.io.FileUtils.forceMkdirParent(java.io.File)'
	at com.vaadin.flow.server.frontend.NodeUpdater.writePackageFile(NodeUpdater.java:287)
	at com.vaadin.flow.server.frontend.NodeUpdater.writeAppPackageFile(NodeUpdater.java:280)
	at com.vaadin.flow.server.frontend.TaskCreatePackageJson.execute(TaskCreatePackageJson.java:60)
	at com.vaadin.flow.server.frontend.NodeTasks.execute(NodeTasks.java:372)
	at com.vaadin.flow.server.startup.DevModeInitializer.initDevModeHandler(DevModeInitializer.java:322)
	at com.vaadin.flow.spring.VaadinServletContextInitializer$DevModeServletContextListener.contextInitialized(VaadinServletContextInitializer.java:323)
	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4683)
```

Updating to 2.6 seems to work fine (on viritin and vaadin side).